### PR TITLE
ParserGo works with fewer temp files

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,20 @@
+---
+name: Question
+about: Ask a question that you could not find in the documentation
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Question**
+...your question...
+
+**Is your question related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Suggested Changes**
+If applicable, please provide any suggestions of how to improve.
+
+**Additional context**
+Add any other context, info, files, etc. related to your question.


### PR DESCRIPTION
gofmt() is changed to send in source code needing gofmt'ing directly into the gofmt process via stdin instead of first being written to a temp file.

This causes a change in output, as shown below.

Old:
```sh
2019/03/29 23:42:55 Error from ParserGoPkg: error parsing "root.vugu": go fmt error exit status 2; full output: /home/erin/workspace/vuguexample/ParserGo451043648.go:32:26: expected ';', found nope
```

New:
```sh
2019/03/29 23:44:43 Error from ParserGoPkg: error parsing "root.vugu": go fmt error exit status 2; full output: <standard input>:32:26: expected ';', found nope
```