### PR TITLE
Added instantiateStreaming polyfill to support Safari

### DIFF
--- a/simplehttp/simple-handler.go
+++ b/simplehttp/simple-handler.go
@@ -402,7 +402,13 @@ var DefaultPageTemplateSource = `<!doctype html>
 {{end}}
 </div>
 <script>
-var wasmSupported = (typeof WebAssembly === "object") && (typeof WebAssembly.instantiateStreaming === "function");
+var wasmSupported = (typeof WebAssembly === "object");
+if (!WebAssembly.instantiateStreaming) { // polyfill
+	WebAssembly.instantiateStreaming = async (resp, importObject) => {
+		const source = await (await resp).arrayBuffer();
+		return await WebAssembly.instantiate(source, importObject);
+	};
+}
 if (wasmSupported) {
 	const go = new Go();
 	WebAssembly.instantiateStreaming(fetch("/main.wasm"), go.importObject).then((result) => {


### PR DESCRIPTION
Safari (both macOS and iOS) have no support for `WebAssemly.instantiateStreaming` (see [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateStreaming)).

This patch polyfills the missing function as suggested by the main [go wasm wiki](https://github.com/golang/go/wiki/WebAssembly) ([code snippet](https://github.com/golang/go/blob/b2fcfc1a50fbd46556f7075f7f1fbf600b5c9e5d/misc/wasm/wasm_exec.html#L17-L22))