### PR TITLE
Fix static fields always considered as attrMap

### DIFF
--- a/gen/parser-util.go
+++ b/gen/parser-util.go
@@ -19,7 +19,7 @@ import (
 func attrFromHtml(attr html.Attribute) vugu.VGAttribute {
 	return vugu.VGAttribute{
 		Namespace: attr.Namespace,
-		Key:       attr.Key,
+		Key:       attr.OrigKey,
 		Val:       attr.Val,
 	}
 }

--- a/wasm-test-suite/test-007-issue-85/.gitignore
+++ b/wasm-test-suite/test-007-issue-85/.gitignore
@@ -1,0 +1,7 @@
+main_wasm.go
+main.wasm
+root.go
+comp.go
+go.sum
+wasm_exec.js
+index.html

--- a/wasm-test-suite/test-007-issue-85/comp.vugu
+++ b/wasm-test-suite/test-007-issue-85/comp.vugu
@@ -1,0 +1,7 @@
+<p vg-html='c.Key'></p>
+
+<script type='application/x-go'>
+  type Comp struct {
+    Key string `vugu:"html"`
+  }
+</script>

--- a/wasm-test-suite/test-007-issue-85/go.mod
+++ b/wasm-test-suite/test-007-issue-85/go.mod
@@ -1,0 +1,10 @@
+module github.com/vugu/vugu/wasm-test-suite/test
+
+replace github.com/vugu/vugu => ../..
+
+go 1.13
+
+require (
+	github.com/vugu/vjson v0.0.0-20191111004939-722507e863cb
+	github.com/vugu/vugu v0.1.1-0.20191208090309-fa72e903246b
+)

--- a/wasm-test-suite/test-007-issue-85/root.vugu
+++ b/wasm-test-suite/test-007-issue-85/root.vugu
@@ -1,0 +1,8 @@
+<html>
+  <head></head>
+  <body>
+    <div id="content">
+      <main:Comp Key='value'></main:Comp>
+    </div>
+  </body>
+</html>

--- a/wasm-test-suite/wasm-suite_test.go
+++ b/wasm-test-suite/wasm-suite_test.go
@@ -11,7 +11,6 @@ import (
 	"html/template"
 	"io"
 	"io/ioutil"
-	"log"
 	"mime/multipart"
 	"net/http"
 	"os"
@@ -171,7 +170,7 @@ func Test006Issue81(t *testing.T) {
 	pathSuffix := mustBuildAndLoad(dir)
 	ctx, cancel := mustChromeCtx()
 	defer cancel()
-	log.Printf("pathSuffix = %s", pathSuffix)
+	// log.Printf("pathSuffix = %s", pathSuffix)
 
 	must(chromedp.Run(ctx,
 		chromedp.Navigate("http://localhost:8846"+pathSuffix),
@@ -197,6 +196,20 @@ func Test006Issue81(t *testing.T) {
 				"wrong body attributes",
 			)
 		}),
+	))
+}
+
+func Test007Issue85(t *testing.T) {
+	dir, origDir := mustUseDir("test-007-issue-85")
+	defer os.Chdir(origDir)
+	mustGen(dir)
+	pathSuffix := mustBuildAndLoad(dir)
+	ctx, cancel := mustChromeCtx()
+	defer cancel()
+
+	must(chromedp.Run(ctx,
+		chromedp.Navigate("http://localhost:8846"+pathSuffix),
+		chromedp.WaitVisible("#content"),
 	))
 }
 


### PR DESCRIPTION
Fix #85

The fix is straightforward. Because the field name case is important since
the last refactor, we should always deal with attr.OrigKey and never attr.Key.

Note: we could remove `attrFromHtml` func and inline it inside `staticVGAttr`, since it's only used here.