### PR TITLE
ignore generated domrender file from diff

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+domrender/renderer-js-script.go -diff


### PR DESCRIPTION
This only brings a more handy way to generate the script, because
currently you need to go to the domrender directory and execute `go run
renderer-js-script-maker.go`, with this you can just run `go generate ./...`
at the root level.

The change also contains a git option to remove the generated file from
the git diff (because it's annoying and useless).

There's room for improvement, like integrating this step in the build
process, but this requires a Makefile or something similar (Mage?).
Moreover something may come from the std lib on that topic :)
https://github.com/golang/go/issues/35950