### PR TITLE
remove lower() call on tokens with colons

### DIFF
--- a/internal/htmlx/token.go
+++ b/internal/htmlx/token.go
@@ -1161,7 +1161,10 @@ func (z *Tokenizer) TagName() (name []byte, hasAttr bool) {
 			s := z.buf[z.data.start:z.data.end]
 			z.data.start = z.raw.end
 			z.data.end = z.raw.end
-			return lower(s), z.nAttrReturned < len(z.attr)
+			if !strings.Contains(string(s), ":") {
+				s = lower(s)
+			}
+			return s, z.nAttrReturned < len(z.attr)
 		}
 	}
 	return nil, false
@@ -1178,7 +1181,10 @@ func (z *Tokenizer) TagAttr() (key, val []byte, moreAttr bool) {
 			z.nAttrReturned++
 			key = z.buf[x[0].start:x[0].end]
 			val = z.buf[x[1].start:x[1].end]
-			return lower(key), unescape(convertNewlines(val), true), z.nAttrReturned < len(z.attr)
+			if !strings.HasPrefix(string(key), ":") {
+				key = lower(key)
+			}
+			return key, unescape(convertNewlines(val), true), z.nAttrReturned < len(z.attr)
 		}
 	}
 	return nil, nil, false


### PR DESCRIPTION
This would resolve the vugufmt lowering mentioned in #192 and #154 (apologies for not looking more before creating my own issue).

The two calls to TagName still use the same code path that they were before in my testing. The related tests also still passed.