### PR TITLE
Fix "ValueOf: invalid value" panics in syscall/js when using vugu/js

### DIFF
--- a/js/impl-js.go
+++ b/js/impl-js.go
@@ -109,7 +109,7 @@ func Global() Value {
 
 // ValueOf alias to syscall/js
 func ValueOf(x interface{}) Value {
-	return Value(sjs.ValueOf(x))
+	return Value(sjs.ValueOf(fixArgToSjs(x)))
 }
 
 // CopyBytesToGo alias to syscall/js
@@ -172,7 +172,7 @@ func (v Value) Get(p string) Value {
 }
 
 func (v Value) Set(p string, x interface{}) {
-	sjs.Value(v).Set(p, x)
+	sjs.Value(v).Set(p, fixArgToSjs(x))
 }
 
 func (v Value) Index(i int) Value {
@@ -180,7 +180,7 @@ func (v Value) Index(i int) Value {
 }
 
 func (v Value) SetIndex(i int, x interface{}) {
-	sjs.Value(v).SetIndex(i, x)
+	sjs.Value(v).SetIndex(i, fixArgToSjs(x))
 }
 
 func (v Value) Length() int {
@@ -229,6 +229,19 @@ func (v Value) IsUndefined() bool {
 
 func (v Value) IsNull() bool {
 	return sjs.Value(v).IsNull()
+}
+
+// fixArgToSjs converts any Value to sjs.Value.
+// This prevents "ValueOf: invalid value" panics.
+func fixArgToSjs(arg interface{}) interface{} {
+	if val, ok := arg.(Value); ok {
+		return sjs.Value(val)
+	}
+	if f, ok := arg.(Func); ok {
+		arg = f.f
+	}
+
+	return arg
 }
 
 func fixArgsToSjs(args []interface{}) []interface{} {

--- a/js/impl-js.go
+++ b/js/impl-js.go
@@ -54,7 +54,7 @@ func FuncOf(fn func(Value, []Value) interface{}) Func {
 		for i := range args {
 			args2[i] = Value(args[i])
 		}
-		return fn(Value(this), args2)
+		return fixArgToSjs(fn(Value(this), args2))
 	}
 
 	f := sjs.FuncOf(fn2)

--- a/wasm-test-suite/test-025-js-value-of/.gitignore
+++ b/wasm-test-suite/test-025-js-value-of/.gitignore
@@ -1,0 +1,8 @@
+main_wasm.go
+main.wasm
+root.go
+comp.go
+go.sum
+wasm_exec.js
+index.html
+*_vgen.go

--- a/wasm-test-suite/test-025-js-value-of/go.mod
+++ b/wasm-test-suite/test-025-js-value-of/go.mod
@@ -1,0 +1,10 @@
+module github.com/vugu/vugu/wasm-test-suite/test
+
+replace github.com/vugu/vugu => ../..
+
+go 1.13
+
+require (
+	github.com/vugu/vjson v0.0.0-20200505061711-f9cbed27d3d9
+	github.com/vugu/vugu v0.1.1-0.20191208090309-fa72e903246b
+)

--- a/wasm-test-suite/test-025-js-value-of/root.vugu
+++ b/wasm-test-suite/test-025-js-value-of/root.vugu
@@ -1,0 +1,9 @@
+<div>
+	<main:Test></main:Test>
+</div>
+
+<script type="application/x-go">
+
+	type Root struct{}
+
+</script>

--- a/wasm-test-suite/test-025-js-value-of/test.vugu
+++ b/wasm-test-suite/test-025-js-value-of/test.vugu
@@ -1,0 +1,30 @@
+<div id="test-div">
+	<div id="source-div">data:image/bmp;base64,Qk32AAAAAAAAADYAAAAoAAAABwAAAAgAAAABABgAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAboqiRFhpEh4kGEJNHSVOFxpFEBkbAAAAxJuCuJqCboOfPY6qVXXAPk2RDBcZAAAAjYF3bEsqqrjJf4eembDERFJUGy49AAAAUnSRAQAAi4SBu87vNk5oCAoKMUthAAAAXoCdGy4/Y2l0i6nMITlRKj1MLkddAAAATW6IGS5DV2F5NE54HDVLQl13JThHAAAAOVNpECIvT1hrGS5PIjlOK0JXIDI/AAAAITpKCh0sBhEaDBoiI0BVGi08GCYwAAAA</div>
+</div>
+
+<script type="application/x-go">
+
+	import (
+		"github.com/vugu/vugu"
+	)
+
+	type Test struct{}
+
+	func (c *Test) Rendered(ctx vugu.RenderedCtx) {
+		document := js.Global().Get("document")
+		testDiv := document.Call("getElementById", "test-div")
+		sourceDiv := document.Call("getElementById", "source-div")
+
+		// Get text content of source element as a js.Value object.
+		someText := sourceDiv.Get("innerText")
+
+		// Do something with the text object.
+		img := document.Call("createElement", "img")
+		img.Set("src", someText) // This would panic if vugu/js passes its js.Value directly to syscall/js without converting it. (Panic: ValueOf: invalid value)
+
+		// Insert image into DOM just because, and to give the test something to check for.
+		testDiv.Call("appendChild", img)
+		img.Set("id", "success-img")
+	}
+
+</script>

--- a/wasm-test-suite/wasm-suite_test.go
+++ b/wasm-test-suite/wasm-suite_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"github.com/chromedp/chromedp/kb"
 	"io/ioutil"
 	"log"
 	"os"
@@ -14,6 +13,7 @@ import (
 
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/chromedp"
+	"github.com/chromedp/chromedp/kb"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -932,4 +932,35 @@ func Test024EventBufferSize(t *testing.T) {
 		log.Println(val)
 	}
 	t.Run("go", func(t *testing.T) { tf(t, mustGenBuildAndLoad(dir)) })
+}
+
+func Test025JSValueOf(t *testing.T) {
+
+	dir, origDir := mustUseDir("test-025-js-value-of")
+	defer os.Chdir(origDir)
+
+	tf := func(t *testing.T, pathSuffix string) {
+
+		assert := assert.New(t)
+
+		ctx, cancel := mustChromeCtx()
+		defer cancel()
+
+		imgURL, imgURLOk := "", false
+
+		must(chromedp.Run(ctx,
+			chromedp.Navigate("http://localhost:8846"+pathSuffix),
+			chromedp.WaitVisible("#success-img"),
+			chromedp.AttributeValue("#success-img", "src", &imgURL, &imgURLOk),
+		))
+
+		// Checking the resulting url. It may not be that important for this test, just in case.
+		assert.Equal("data:image/bmp;base64,Qk32AAAAAAAAADYAAAAoAAAABwAAAAgAAAABABgAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAboqiRFhpEh4kGEJNHSVOFxpFEBkbAAAAxJuCuJqCboOfPY6qVXXAPk2RDBcZAAAAjYF3bEsqqrjJf4eembDERFJUGy49AAAAUnSRAQAAi4SBu87vNk5oCAoKMUthAAAAXoCdGy4/Y2l0i6nMITlRKj1MLkddAAAATW6IGS5DV2F5NE54HDVLQl13JThHAAAAOVNpECIvT1hrGS5PIjlOK0JXIDI/AAAAITpKCh0sBhEaDBoiI0BVGi08GCYwAAAA", imgURL)
+
+	}
+
+	t.Run("go", func(t *testing.T) { tf(t, mustGenBuildAndLoad(dir)) })
+	// BUG: Test 025 times out with tinygo
+	//t.Run("tinygo", func(t *testing.T) { tf(t, mustTGGenBuildAndLoad(dir, nil)) })
+
 }


### PR DESCRIPTION
This is a straight forward fix for the problem that syscall/js doesn't know about vugu/js value.