### PR TITLE
Fix relative paths in mustUploadDir

### DIFF
--- a/wasm-test-suite/wasm-suite-util_test.go
+++ b/wasm-test-suite/wasm-suite-util_test.go
@@ -15,7 +15,6 @@ import (
 	"mime/multipart"
 	"net/http"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -265,14 +264,20 @@ func mustUploadDir(dir, endpoint string) string {
 
 		absPath, err := filepath.Abs(fpath)
 		if err != nil {
-			panic(err)
+			return err
 		}
 
-		relPath := path.Clean("/" + strings.TrimPrefix(absPath, absDir))
+		relPath, err := filepath.Rel(absDir, absPath)
+		if err != nil {
+			return err
+		}
 
 		// log.Printf("path = %q, fi.Name = %q", path, fi.Name())
 		hdr, err := tar.FileInfoHeader(fi, "")
-		hdr.Name = relPath
+		if err != nil {
+			return err
+		}
+		hdr.Name = filepath.ToSlash(relPath)
 		// hdr = tar.Header{
 		// 	Name: fi.Name(),
 		// 	Mode: 0644,


### PR DESCRIPTION
Generated tar archive names were not independent of OS paths. Now they are, and it's possible to run the tests on windows machines.