### PR TITLE
Add missing syscall/js functions

### DIFF
--- a/js/impl-js.go
+++ b/js/impl-js.go
@@ -175,6 +175,10 @@ func (v Value) Set(p string, x interface{}) {
 	sjs.Value(v).Set(p, x)
 }
 
+func (v Value) Delete(p string) {
+	sjs.Value(v).Delete(p)
+}
+
 func (v Value) Index(i int) Value {
 	return Value(sjs.Value(v).Index(i))
 }
@@ -219,6 +223,10 @@ func (v Value) String() string {
 	return sjs.Value(v).String()
 }
 
+func (v Value) Equal(w Value) bool {
+	return sjs.Value(v).Equal(sjs.Value(w))
+}
+
 func (v Value) InstanceOf(t Value) bool {
 	return sjs.Value(v).InstanceOf(sjs.Value(t))
 }
@@ -229,6 +237,10 @@ func (v Value) IsUndefined() bool {
 
 func (v Value) IsNull() bool {
 	return sjs.Value(v).IsNull()
+}
+
+func (v Value) IsNaN() bool {
+	return sjs.Value(v).IsNaN()
 }
 
 func fixArgsToSjs(args []interface{}) []interface{} {

--- a/js/impl-nonjs.go
+++ b/js/impl-nonjs.go
@@ -138,6 +138,10 @@ func (v Value) Set(p string, x interface{}) {
 	panic(errNotImpl)
 }
 
+func (v Value) Delete(p string) {
+	panic(errNotImpl)
+}
+
 func (v Value) Index(i int) Value {
 	return Undefined()
 }
@@ -182,6 +186,10 @@ func (v Value) String() string {
 	return ""
 }
 
+func (v Value) Equal(w Value) bool {
+	return false
+}
+
 func (v Value) InstanceOf(t Value) bool {
 	return false
 }
@@ -191,5 +199,9 @@ func (v Value) IsUndefined() bool {
 }
 
 func (v Value) IsNull() bool {
+	return false
+}
+
+func (v Value) IsNaN() bool {
 	return false
 }

--- a/js/impl-nonjs.go
+++ b/js/impl-nonjs.go
@@ -117,6 +117,7 @@ type Wrapper interface {
 
 // Value placeholder for syscall/js
 type Value struct {
+	_    [0]func() // uncomparable; to make == not compile
 	stub uint64
 }
 


### PR DESCRIPTION
- Add `value.Delete(...)`
- Add `value.Equal(...)`
- Add `value.IsNAN()`
- Prevent values from being compared, similar to how `syscall/js` does it.