### PR TITLE
Use Github Actions instead of Travis

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,41 @@
+name: Go tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ '1.14.15', '1.15.15' ]
+    env:
+      GO111MODULE: "on"
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go }}
+
+    - name: before_install from Travis
+      run: go get golang.org/x/tools/cmd/goimports && go install golang.org/x/tools/cmd/goimports
+    - run: docker pull vugu/wasm-test-suite:latest
+    - run: docker run -d -t -p 9222:9222 -p 8846:8846 --name wasm-test-suite vugu/wasm-test-suite:latest
+
+    - name: Main script
+      run: go install ./cmd/vugugen
+    - run: go test .
+    - run: go test ./devutil
+    - run: go test ./distutil
+    - run: go test ./domrender
+    - run: go test ./gen
+    - run: go test ./js
+    - run: go test ./staticrender
+    - run: go test ./simplehttp
+    - run: go test ./vgform
+    - run: go test ./wasm-test-suite


### PR DESCRIPTION
I couldn't register my fork on Travis CI, so I decided to just use Github actions instead.