### PR TITLE
Fix glibc issues

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,7 +24,7 @@ jobs:
 
     - name: before_install from Travis
       run: go get golang.org/x/tools/cmd/goimports && go install golang.org/x/tools/cmd/goimports
-    - run: docker pull vugu/wasm-test-suite:latest
+    - run: cd wasm-test-suite/docker && ./make-docker.sh
     - run: docker run -d -t -p 9222:9222 -p 8846:8846 --name wasm-test-suite vugu/wasm-test-suite:latest
     - run: wget -O /tmp/tinygo.deb https://github.com/tinygo-org/tinygo/releases/download/v0.22.0/tinygo_0.22.0_amd64.deb ; sudo dpkg -i /tmp/tinygo.deb
 

--- a/wasm-test-suite/docker/make-docker.sh
+++ b/wasm-test-suite/docker/make-docker.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Go build for linux
-GOOS=linux GOARCH=amd64 go build -o wasm-test-suite-srv .
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o wasm-test-suite-srv .
 
 # Docker build and tag image
 docker build -t vugu/wasm-test-suite:latest .


### PR DESCRIPTION
Hello,

This PR goes with https://github.com/vugu/vugu/issues/246 requirements.

It solves this issue:
```bash
cd wasm-test-suite/docker
./make-docker.sh
...
.....
.......

docker run -ti --rm -p 9222:9222 -p 8846:8846 vugu/wasm-test-suite:latest
/bin/wasm-test-suite-srv: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /bin/wasm-test-suite-srv)
/bin/wasm-test-suite-srv: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /bin/wasm-test-suite-srv)
```