### PR TITLE
Improve foundMountEl error message from visitBody func

### DIFF
--- a/gen/parser-go.go
+++ b/gen/parser-go.go
@@ -447,7 +447,7 @@ func (p *ParserGo) visitBody(state *parseGoState, n *html.Node) error {
 		}
 
 		if foundMountEl {
-			return fmt.Errorf("element %q found after we already have a mount element", childN.Data)
+			return fmt.Errorf("element %q found after we already have a mount element, you might have to wrap all your body content into a div", childN.Data)
 		}
 		foundMountEl = true
 


### PR DESCRIPTION
Hello,

This PR goes with https://github.com/vugu/vugu/issues/246 requirements.

When I was doing some tests, I was having a body like:
```html
<body>
<div>1st div</div>
<div>2nd div</div>
</body>
```

instead of:

```html
<body>
<div>
  <div>1st div</div>
  <div>2nd div</div>
</div>
</body>
```

The original error message wasn't clear.
