### PR TITLE
Install golangci-lint with deb package instead of building it

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,7 +24,7 @@ jobs:
 
     - name: before_install from Travis
       run: go get golang.org/x/tools/cmd/goimports && go install golang.org/x/tools/cmd/goimports
-    - run: wget -O /tmp/golangci-lint.deb https://golangci/golangci-lint/releases/download/v1.55.2/golangci-lint-1.55.2-linux-amd64.deb ; sudo dpkg -i /tmp/golangci-lint.deb
+    - run: wget -O /tmp/golangci-lint.deb https://github.com/golangci/golangci-lint/releases/download/v1.55.2/golangci-lint-1.55.2-linux-amd64.deb ; sudo dpkg -i /tmp/golangci-lint.deb
     - name: Execute golangci-lint
       run: golangci-lint run
     - run: docker pull vugu/wasm-test-suite:latest

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,7 +24,7 @@ jobs:
 
     - name: before_install from Travis
       run: go get golang.org/x/tools/cmd/goimports && go install golang.org/x/tools/cmd/goimports
-    - run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+    - run: wget -O /tmp/golangci-lint.deb https://golangci/golangci-lint/releases/download/v1.55.2/golangci-lint-1.55.2-linux-amd64.deb ; sudo dpkg -i /tmp/golangci-lint.deb
     - name: Execute golangci-lint
       run: golangci-lint run
     - run: docker pull vugu/wasm-test-suite:latest


### PR DESCRIPTION
Hello @bradleypeabody @owenwaller ,

I'm just changing the way of installing `golangci-lint` to avoid golang version issues.
It's related to https://github.com/vugu/vugu/pull/252#issuecomment-1826965915 for `go 1.17.x`