### PR TITLE
Correct the vugufmt test failure

### DIFF
--- a/vugufmt/doc.go
+++ b/vugufmt/doc.go
@@ -1,2 +1,2 @@
-//Package vugufmt provides gofmt-like functionality for vugu files.
+// Package vugufmt provides gofmt-like functionality for vugu files.
 package vugufmt


### PR DESCRIPTION
Correct the vugufmt test failure by correcting the doc.go file to add an additional space to the comment. The test failure was in TestGoFmtNoError

This fix is also part of PR261. This commit breaks the fix out.