### PR TITLE
Use a Taskfile to build and test vugu

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,0 +1,133 @@
+# Taskfile for 'vugu'
+# 
+# The Taskfile builds vugu, runs all the tests and lints the source code.
+
+version: '3'
+
+# TODO: Warning this task file assumes Linux is the OS. The Taskfile will need to reworked to strip the Linux only shell cmds
+tasks:
+  # Build everything, run all the tests (using go, tinygo and tinygo in docker) and lint the codebase
+  all:
+    preconditions:
+      - task: check-cmds-exist
+    cmds:
+      - task: clean-vgform
+      - task: clean-wasm-test-suite
+      - task: build
+      - task: test
+      - task: test-wasm
+      - task: lint
+
+
+  # Build the vugu packages and the vugugen and vugufmt commands
+  build:
+    cmds:
+      # note we now use the full package names
+      # we have to run go generate in the vgform package
+      - go generate github.com/vugu/vugu/vgform
+      # build and install the vugu package
+      - go install github.com/vugu/vugu
+      # build and install the vugugen command
+      - go install github.com/vugu/vugu/cmd/vugugen
+      # build and install the vugufmt command
+      - go install github.com/vugu/vugu/cmd/vugufmt
+
+
+  # Run all of the tests - except the wasm-test-suite. The wasm-test-suite currently takes circa 35 minutes to execute.
+  # Some of the tests (e.g. in the devutil package) are build using tinygo, so a locally installed tiny go is a prerequisite.
+  test:
+    # it's a precondition is that tinygo is available
+    preconditions:
+      - task: check-cmds-exist
+      - sh: command -v tinygo
+        msg: "tinygo not found. Please see https://tinygo.org/getting-started/install/ for how to install locally"  
+    cmds:
+      # run all of the tests EXCEPT the wasm-test-suite (we use go list ./... to list all the packages and then ignore wasm-test-suite via the "-v" in the grep)
+      - go test `go list ./... | grep -v wasm-test-suite`
+  
+
+  # Run just the wasm-test-suite tests. This can take up to 35 minutes to complete.
+  # The wasm-test suite builds all of the tests three times - once using go, once using tinygo and once using tinygo installed in a docker container
+  # Therefore docker is a prerequisite to run these tests along with tinygo.
+  # The docker container that is started is named `wasm-test-suite`. It will be stopped and removed once the tests are complete.
+  # The tests are servered by a small Go http server - the wasm-test-suite-srv executeable. This is build prior to the tests being run. It is installed in the
+  # 'wasm-test-suite' container
+  test-wasm:
+    dir:
+      # This task must be executed from the local "wasm-test-suite/docker" directory. The contents of the Dockerfile rely on this.
+      # The 'wasm-test-suite-srv' executable will be put into the "wasm-test-suite/docker" directory.
+      ./wasm-test-suite/docker
+    # the precondition is docker and tinygo are both available
+    preconditions:
+      - sh: command -v tinygo
+        msg: "tinygo not found. Please see https://tinygo.org/getting-started/install/ for how to install locally"  
+      - sh: command -v docker
+        msg: "docker not found. Please see https://docs.docker.com/desktop/ for how to install locally"  
+    cmds:
+      # build the wasm-test-suite-srv. Note we build via the package name.
+      - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./wasm-test-suite-srv github.com/vugu/vugu/wasm-test-suite/docker
+      # docker build and tag our image
+      - docker build -t vugu/wasm-test-suite:latest .
+      # we want to ignore any failures e.g. the wasm-test-suite container wasn't running so we have to use "cmd:" to be explicit which error
+      # we want to ignore.
+      - cmd: 'docker stop wasm-test-suite'
+        ignore_error: true
+      # ditto, be explit so it's clear we are ignoring any 'docker rm' error
+      - cmd: 'docker rm wasm-test-suite'
+        ignore_error: true
+      # start the container
+      - docker run -d -t -p 9222:9222 -p 8846:8846 --name wasm-test-suite vugu/wasm-test-suite:latest
+      # stop the container and cleanup once the task is complete
+      - defer: docker stop wasm-test-suite
+      # run the tests
+      # set the timeout for 35 minutes, as the tests can timeout between 20 and 35 minutes depending on the hardware
+      # and enable verbose output otherwise it looks like this hangs.
+      - go test -v -timeout=35m github.com/vugu/vugu/wasm-test-suite
+      
+
+  # Run the linter
+  lint:
+    # we use 'golangci-lint' as a meta linter, so it's availability is a prerequisite.
+    preconditions:
+      - sh: command -v golangci-lint
+        msg: "glangci-lint not found. Please see https://golangci-lint.run/usage/install/#local-installation for how to install locally"  
+    cmds:
+      - golangci-lint run .
+
+
+  # Remove all of the generated files in the vgform package
+  clean-vgform:
+    # both the 'find' and 'rm' commands are prerequisites
+    preconditions:
+      - task: check-cmds-exist
+    cmds:
+      # We need to delete one of these after (or if) PR261 is merged
+      # old version - uses the "_vgen" suffix
+      - find ./vgform -type f -name "*_vgen.go" -exec rm {} \;
+      # new version post PR261 uses the newer "_gen" suffix.  
+      - find ./vgform -type f -name "*_gen.go" -exec rm {} \;
+
+
+  # Remove all of the generated files in the 'wasm-test-suite' package
+  clean-wasm-test-suite:
+    preconditions:
+      - task: check-cmds-exist
+    cmds:
+      # We need to delete one of these after (or if) PR261 is merged
+      # old version - uses the "_vgen" suffix
+      - find ./wasm-test-suite -type f -name "*_vgen.go" -exec rm {} \;
+      # new version post PR261 uses the newer "_gen" suffix.  
+      - find ./wasm-test-suite -type f -name "*_gen.go" -exec rm {} \;
+
+
+  # Check that the (linux) tools we rely on are present.
+  # We will need to change these to check for he platform specific equivalents.
+  check-cmds-exist:
+    preconditions:
+    - sh: command -v find
+      msg: "find command not found."
+    - sh: command -v grep
+      msg: "grep command not found."
+    - sh: command -v rm
+      msg: "rm command not found."
+

--- a/wasm-test-suite/docker/go.mod
+++ b/wasm-test-suite/docker/go.mod
@@ -1,5 +1,0 @@
-module main
-
-// module github.com/vugu/vugu/wasm-test-suite-srv/main
-
-go 1.21.4


### PR DESCRIPTION
Use a Taskfile (see: https://taskfile.dev/) to build the vugu packages, the vugugen and vugufmt command line tools, run all of the tests, and lint the source code.

This simplifies building vugu locally. All that is required now is

$ task all

at the top level of the repo. The Taskfile.yaml is fully documented.

Note: this is an initial version that only supports Linux as it relies on command line utilities that are installed by default on Linux. In addition it assumes that docker, tinygo and the golangci-lint tools are all installed locally. If they are not found then the task will abort. Supporting Windows will require changing the tasks to support the Windows PowerShell equivalents when the task in run on Windows.