### PR TITLE
Import `log` package by default into `*_gen.go`

### DIFF
--- a/gen/parser-go.go
+++ b/gen/parser-go.go
@@ -257,6 +257,7 @@ func (p *ParserGo) visitOverall(state *parseGoState) error {
 	fmt.Fprintf(&state.goBuf, "import %q\n", "github.com/vugu/vjson")
 	fmt.Fprintf(&state.goBuf, "import %q\n", "github.com/vugu/vugu")
 	fmt.Fprintf(&state.goBuf, "import js %q\n", "github.com/vugu/vugu/js")
+	fmt.Fprintf(&state.goBuf, "import %q\n", "log")
 	fmt.Fprintf(&state.goBuf, "\n")
 
 	// TODO: we use a prefix like "vg" as our namespace; should document that user code should not use that prefix to avoid conflicts
@@ -276,6 +277,7 @@ func (p *ParserGo) visitOverall(state *parseGoState) error {
 	fmt.Fprintf(&state.goBufBottom, "var _ reflect.Type\n")
 	fmt.Fprintf(&state.goBufBottom, "var _ vjson.RawMessage\n")
 	fmt.Fprintf(&state.goBufBottom, "var _ js.Value\n")
+	fmt.Fprintf(&state.goBufBottom, "var _ log.Logger\n")
 	fmt.Fprintf(&state.goBufBottom, "\n")
 
 	// remove document node if present

--- a/wasm-test-suite/docker/wasm-test-suite-srv.go
+++ b/wasm-test-suite/docker/wasm-test-suite-srv.go
@@ -148,6 +148,5 @@ func (s *TSrv) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// fall through to static file server on BaseDir
 	http.FileServer(http.Dir(s.BaseDir)).ServeHTTP(w, r)
-	return
 
 }


### PR DESCRIPTION
Hello, @bradleypeabody @owenwaller 

This PR is based on Issues #181
`*_gen.go` files generation will be changed in this PR as follows.
```.diff
package main

import "fmt"
import "reflect"
import "github.com/vugu/vjson"
import "github.com/vugu/vugu"
import js "github.com/vugu/vugu/js"
+ import "log"

/*
omit
*/

// 'fix' unused imports
var _ fmt.Stringer
var _ reflect.Type
var _ vjson.RawMessage
var _ js.Value
+ var _ log.Logger
```

Not related to this PR, but I modified the following file to pass CI(golangci-lint).

- wasm-test-suite/docker/wasm-test-suite-srv.go

Thank you. 