### PR TITLE
Remove the replace directive for vugu and pin to v0.4.0

### DIFF
--- a/wasm-test-suite/test-002-click/go.mod
+++ b/wasm-test-suite/test-002-click/go.mod
@@ -1,14 +1,11 @@
 module github.com/vugu/vugu/wasm-test-suite/test-002-click
 
-replace github.com/vugu/vugu => ../..
-
 go 1.22.3
 
 require (
 	github.com/chromedp/chromedp v0.9.5
 	github.com/stretchr/testify v1.9.0
-	github.com/vugu/vjson v0.0.0-20200505061711-f9cbed27d3d9
-	github.com/vugu/vugu v0.0.0-00010101000000-000000000000
+	github.com/vugu/vugu v0.4.0
 )
 
 require (
@@ -21,6 +18,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/vugu/vjson v0.0.0-20200505061711-f9cbed27d3d9 // indirect
 	github.com/vugu/xxhash v0.0.0-20191111030615-ed24d0179019 // indirect
 	golang.org/x/sys v0.20.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/wasm-test-suite/test-002-click/go.sum
+++ b/wasm-test-suite/test-002-click/go.sum
@@ -28,6 +28,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/vugu/vjson v0.0.0-20200505061711-f9cbed27d3d9 h1:0cwYt2uGUAwxOYF6zAkVvCKWt8zOV3JhQqjvwKb6jf0=
 github.com/vugu/vjson v0.0.0-20200505061711-f9cbed27d3d9/go.mod h1:z7mAqSUjRDMQ09NIO18jG2llXMHLnUHlZ3/8MEMyBPA=
+github.com/vugu/vugu v0.4.0 h1:ijU94l+qELec5f+Bb9R8m4fvZkhm4sKhawfmQVCV9a8=
+github.com/vugu/vugu v0.4.0/go.mod h1:JU3YFROwFOqodkf1q8c1IRcx92j/dq258cqpaCsDlM8=
 github.com/vugu/xxhash v0.0.0-20191111030615-ed24d0179019 h1:8NGiD5gWbVGObr+lnqcbM2rcOQBO6mr+m19BIblCdho=
 github.com/vugu/xxhash v0.0.0-20191111030615-ed24d0179019/go.mod h1:PrBK6+LJXwb+3EnJTHo43Uh4FhjFFwvN4jKk4Zc5zZ8=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
Remove the replace directive to github.com/vugu/vugu => ../../ and see if this now passes a Github Action run.

Doing so causes `test-002-click` to build when it was previously failing via Github Actions.