### PR TITLE
Update the vugu dependency from a pseudo version to v0.3.5

### DIFF
--- a/wasm-test-suite/test-002-click/go.mod
+++ b/wasm-test-suite/test-002-click/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/chromedp/chromedp v0.9.5
 	github.com/stretchr/testify v1.9.0
 	github.com/vugu/vjson v0.0.0-20200505061711-f9cbed27d3d9
-	github.com/vugu/vugu v0.0.0-00010101000000-000000000000
+	github.com/vugu/vugu v0.3.5
 )
 
 require (


### PR DESCRIPTION
Upgrade the vugu dependency from a pseudo version to v0.3.5 V0.3.5 is the release prior to v0.4.0. Then use a replace directive to replace

github.com/vugu/vugu => ../../

So that when the test then builds uses the local source code.

This change still fails on Github Actions. See:

https://github.com/owenwaller/vugu/actions/runs/9399018030