### PR TITLE
pinned to older chrome version

### DIFF
--- a/legacy-wasm-test-suite/docker/Dockerfile
+++ b/legacy-wasm-test-suite/docker/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM chromedp/headless-shell:latest
+FROM chromedp/headless-shell:125.0.6422.142
 
 RUN apt-get update && apt-get install dumb-init
 


### PR DESCRIPTION
This is to fix the issue with the legacy test suite where it looks like it was erroring due to the remote debugging functionality changing.  To fix this up properly to work with the latest version would require further reworking the guts of the docker setup for this so I instead just pinned it to the last working version.  The plan is to get rid of this entirely in the long run so I think this is fine.