### PR TITLE
Add support for a nginx config file for the nginx container in the wa…

### DIFF
--- a/magefiles/dockercmd.go
+++ b/magefiles/dockercmd.go
@@ -55,9 +55,10 @@ func createContainerNetwork(networkName string) error {
 
 func startNginxContainer(dirToServe string) error {
 	// note we must prefix "./" to the dirToServe as the mount requires an absolute path
-	mountArg := "type=bind,source=./" + dirToServe + ",target=/usr/share/nginx/html,readonly"
+	htmlMountArg := "type=bind,source=./" + dirToServe + ",target=/usr/share/nginx/html,readonly"
+	configMountArg := "type=bind,source=./wasm-test-suite/nginx-test.conf,target=/usr/share/nginx/config/config.d/nginx-test.conf,readonly"
 	// start the nginx container and attach it to the new vugu-net network
-	return dockerCmdV("run", "--name", VuguNginxContainerName, "--network", VuguContainerNetworkName, "--mount", mountArg, "-p", "8888:80", "-d", "nginx")
+	return dockerCmdV("run", "--name", VuguNginxContainerName, "--network", VuguContainerNetworkName, "--mount", htmlMountArg, "--mount", configMountArg, "-p", "8888:80", "-d", "nginx")
 }
 
 func startLocalNginxContainer(dirToServe string) error {

--- a/wasm-test-suite/nginx-test.conf
+++ b/wasm-test-suite/nginx-test.conf
@@ -1,0 +1,8 @@
+# Global nginx config for the wasm-test-suite
+# This file is shared across all of the wasm-test-suite becuase they all run within the same ngix container.
+# Please put any test specific rewrites or confic in here.
+
+# Add a rewrite rules for test-012 that maps /test-012-router/page1 and /test-012-router/page2 urls back to /test-012-router/index.html
+location /test-012-router/page[0..9]+ {
+		rewrite /test-012-router/page[0..9]+ ^/test-012-router/index.html$ break;
+	}


### PR DESCRIPTION
…sm-test-suite

Wasm test test-012-router needs the HTML server to rewrite the urls /test-012/router/page1
and
/test-012-router/page1
to
/test-012-router/index.html

This requires adding an cnfig file to nginx.

This change adds a global nginx config file that supports this rewrite and mounts the config file under /etc/nginx/config/config.d in the container.

nginx will by default process any *.conf files found under /etc/nginx/config/config.d