### PR TITLE
Restore the ability to build, test and run examples locally with a dirty repo

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -41,4 +41,4 @@ jobs:
       run: mage --version
 
     - name: Build and test vugu including the legecy wasm test suite
-      run: mage -v AllWithLegacyWasm
+      run: mage -v AllGithubAction


### PR DESCRIPTION
The approach to checking for outdated generated files in the repo was a little overzealous. It actually prevented building locally if the git repo was dirty i.e. had modified files.

This commit corrects that, by restoring the ability to build, test, and run the examples locally with a dirty repo.

The magefile now supports 6 new targets:

BuildWithGeneratedFilesCheck - which is like Build but adds the generated file check

TestWasmWithGeneratedFilesCheck - which is like TestWasm but adds the generated file check

TestSingleWasmTestWithGeneratedFilesCheck - which is like TestSingleWasmTest but adds the generated file check

ExamplesWithGeneratedFilesCheck - which is like Examples but adds the generated file check.

SingleExampleWithGeneratedFilesCheck - which is like SingleExample but adds the generated file check

These are now driven by a new top level target, AllGitHubAction, which as the name implies is the target now used buy the Github Action. This always performs the generated files checks as well as always building and running the legacy wasm test suite.