### PR TITLE
Add a new target SingleWasmTest to build and serve a single wasm test

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -427,9 +427,48 @@ func SingleExampleWithGeneratedFilesCheck(moduleName string) error {
 func singleExample(moduleName string, withGeneratedFilesCheck bool) error {
 	mg.SerialDeps(Build, PullLatestNginxImage)
 	StartLocalNginxForExamples()
+	return buildSingleModule(ExamplesDir, moduleName, withGeneratedFilesCheck)
+}
+
+// Builds, and serves a single wasm test using a local nginx container.
+// The usage is:
+//
+//	mage SingleWasmtest <wasm-test-module-name>
+//
+// e.g.
+//
+//	mage SingleExample gtihub.com/vugu/vugu/wasm-test-suite/test-002-click
+//
+// The examples will be served at
+//
+//	http://localhost:8888/<name-of-wasm-test-directory>
+//
+// for example for the test-0020-click
+//
+//	http://localhost:8888/test-0020-click
+//
+// The 'wasm' files are built using the standard Go compiler.
+func SingleWasmTest(moduleName string) error {
+	return singleWasmTest(moduleName, false)
+}
+
+// Like SingleExample but additionally confirm that the generated files that should have been committed are correct.
+func SingleWasmTestWithGeneratedFilesCheck(moduleName string) error {
+	return singleWasmTest(moduleName, true)
+}
+
+func singleWasmTest(moduleName string, withGeneratedFilesCheck bool) error {
+	mg.SerialDeps(Build, PullLatestNginxImage)
+	StartLocalNginxForExamples()
+	return buildSingleModule(WasmTestSuiteDir, moduleName, withGeneratedFilesCheck)
+}
+
+func buildSingleModule(dir string, moduleName string, withGeneratedFilesCheck bool) error {
+	mg.SerialDeps(Build, PullLatestNginxImage)
+	StartLocalNginxForExamples()
 
 	// find all the modules under dir
-	allmodules, err := modulesUnderDir(ExamplesDir)
+	allmodules, err := modulesUnderDir(dir)
 	if err != nil {
 		return err
 	}

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -465,7 +465,6 @@ func singleWasmTest(moduleName string, withGeneratedFilesCheck bool) error {
 
 func buildSingleModule(dir string, moduleName string, withGeneratedFilesCheck bool) error {
 	mg.SerialDeps(Build, PullLatestNginxImage)
-	StartLocalNginxForExamples()
 
 	// find all the modules under dir
 	allmodules, err := modulesUnderDir(dir)


### PR DESCRIPTION
Added a pair of new targets:

SingleWasmTest and SingleWasmTestWithGeneratedFileCheck

Both targets start the named wasm-test-suite module, and serve it via a local nginx instance.

For example:

mage SingleExample gtihub.com/vugu/vugu/wasm-test-suite/test-002-click

would be served at:

http://localhost:8888/test-0020-click

This is useful if the behaviour of a test or the structure of the HTML has to be examined in a browser. This can be useful in debugging the tests.

The SingleWasmTestWithGeneratedFilesCheck target is the same but adds the generated files check.