### PR TITLE
Build vugu with last two supported Go versions

### DIFF
--- a/.github/workflows/go-oldstable.yml
+++ b/.github/workflows/go-oldstable.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ 'oldstable', 'stable' ]
+        go: [ 'oldstable' ]
     env:
       GO111MODULE: "on"
     steps:

--- a/.github/workflows/go-oldstable.yml
+++ b/.github/workflows/go-oldstable.yml
@@ -1,4 +1,4 @@
-name: Go tests
+name: Vugu build using Go @ oldstable
 
 on:
   push:

--- a/.github/workflows/go-stable.yml
+++ b/.github/workflows/go-stable.yml
@@ -1,4 +1,4 @@
-name: Go tests
+name: Vugu build using Go @ stable
 
 on:
   push:

--- a/.github/workflows/go-stable.yml
+++ b/.github/workflows/go-stable.yml
@@ -1,0 +1,43 @@
+name: Go tests
+
+on:
+  push:
+    branches:
+      - master
+      - PR/** # Build on any branch named PR/<something> from https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ 'stable' ]
+    env:
+      GO111MODULE: "on"
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '${{ matrix.go }}'
+
+    - name: Install goinports
+      run: go get golang.org/x/tools/cmd/goimports && go install golang.org/x/tools/cmd/goimports
+
+    - name: Print Go version
+      run: go version
+
+    - name: Install mage
+      run: |
+        git clone https://github.com/magefile/mage /tmp/mage
+        cd /tmp/mage && go run bootstrap.go
+        rm -rf /tmp/mage
+
+    - name: Print mage version
+      run: mage --version
+
+    - name: Build and test vugu including the legecy wasm test suite
+      run: mage -v AllGithubAction

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,8 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go:
-        - '1.22.3'
+        go: [ 'oldstable', 'stable' ]
     env:
       GO111MODULE: "on"
     steps:
@@ -25,11 +24,11 @@ jobs:
       with:
         go-version: '${{ matrix.go }}'
 
-    - name: Install task command
-      uses: arduino/setup-task@v2 # setup task via a Github action maintained by the Arduino community. This will pull task v 3.X
-    
     - name: Install goinports
       run: go get golang.org/x/tools/cmd/goimports && go install golang.org/x/tools/cmd/goimports
+
+    - name: Print Go version
+      run: go version
 
     - name: Install mage
       run: |


### PR DESCRIPTION
Now that the go v1.22 `for` loop shadowing changes are the default, and go v1.23 has been released we can now support building `vugu` with the last two supported versions of Go - aka `stable` and `oldstable`.

The definition of `stable` and `oldstable` is per the [go-versions](https://github.com/actions/go-versions/blob/main/versions-manifest.json) repo. Basically Go v1.X and Go v1.(X-1) both at the latest patch level.

Currently the `stable` build fails because `tinygo` does not yet support go v1.23. This will resolve itself in time, once the latest `tinygo` docker container is updated so support go v1.23.

The `oldstable` build completes normally without error.

Github Action jobs are only cleanly separated into a different containers/vm's(?) if each job is a separate YAML file. We require this separation because the build process relies on Docker and the docker command will make changes visible to any process running on the same container/vm - i.e. the state of the docker host is changed. As a result we have two near identical YAML files one for each of `stable` and `oldstable`.

It's not clear if/how the duplication can be reduced - however as these files are unlikely to change very much, as most of the build process is controlled by the `magefile`, this duplication seems to be acceptable.

The jobs are named `vugu build using Go @ [stable | oldstable]` to make it clear which version of Go was used.
