### PR TITLE
Re-enable linting via golangci-lint

### DIFF
--- a/gen/missing-fixer.go
+++ b/gen/missing-fixer.go
@@ -313,6 +313,8 @@ func readVugugenComments(pkgPath string) (map[string][]string, error) {
 // fileInPackage given pkg and "blah.go" will return the file whose base name is "blah.go"
 // (i.e. it ignores the directory part of the map key in pkg.Files)
 // Will return nil if not found.
+//
+//nolint:staticcheck // ast.Package is deprecated as of Go 1.23
 func fileInPackage(pkg *ast.Package, fileName string) *ast.File {
 	for fpath, file := range pkg.Files {
 		if filepath.Base(fpath) == fileName {
@@ -324,6 +326,8 @@ func fileInPackage(pkg *ast.Package, fileName string) *ast.File {
 
 // findTypeDecl looks through the package for the given type and returns
 // the declaraction or nil if not found
+//
+//nolint:staticcheck // ast.Package is deprecated as of Go 1.23
 func findTypeDecl(fset *token.FileSet, pkg *ast.Package, typeName string) ast.Decl {
 	for _, file := range pkg.Files {
 		for _, decl := range file.Decls {

--- a/gen/parser-go-pkg.go
+++ b/gen/parser-go-pkg.go
@@ -465,7 +465,7 @@ func goGuessPkgName(pkgPath string) (ret string) {
 		goto checkMore
 	}
 	{
-		var pkg *ast.Package
+		var pkg *ast.Package //nolint:staticcheck // ast.Package is deprecated as of Go 1.23
 		for _, pkg1 := range pkgs {
 			pkg = pkg1
 		}
@@ -507,8 +507,7 @@ func goPkgCheckNames(pkgPath string, names []string) (map[string]interface{}, er
 	if len(pkgs) != 1 {
 		return ret, fmt.Errorf("unexpected package count after parsing, expected 1 and got this: %#v", pkgs)
 	}
-
-	var pkg *ast.Package
+	var pkg *ast.Package //nolint:staticcheck // ast.Package is deprecated as of Go 1.23
 	for _, pkg1 := range pkgs {
 		pkg = pkg1
 	}

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -9,7 +9,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -106,19 +105,14 @@ func PullLatestGolangCiLintDockerImage() error {
 	return dockerPullImage(GoLangCiLintImageName)
 }
 
-// Linting is current disabled, pending resolution of issue #320, See https://github.com/vugu/vugu/issues/302.
 // Lint the 'vugu' source code including the tests, and examples and any generated files. The linter used is a dockerized version of the 'golangci-lint' linter.
 // See: https://golangci-lint.run/ for more details of the linter
 func Lint() error {
-	log.Printf("Linting is current disabled, pending resolution of issue #320, See https://github.com/vugu/vugu/issues/302.")
-	return nil
-
-	// uncomment to renable the linter
-	// mg.SerialDeps(
-	// 	Build,
-	// 	PullLatestGolangCiLintDockerImage,
-	// )
-	// return runGolangCiLint()
+	mg.SerialDeps(
+		Build,
+		PullLatestGolangCiLintDockerImage,
+	)
+	return runGolangCiLint()
 }
 
 // Builds and runs all of the Go unit tests for 'vugu', except the 'legacy-wasm-test-suite' tests using the standard Go compiler.


### PR DESCRIPTION
Using a golangci-lint directive of the form:

//nolint:staticcheck // reason why staticcheck has been disabled

We can disable the use of the staticcheck linter completely at the blocks or lines where is is currently reporting the use of the deprecated ast.Package stuct.

This approach is documented here:
https://golangci-lint.run/usage/false-positives/#nolint-directive

At present golangci-lint will ignore staticheck //lint:ignore style directives. This issues has been raised with the golangci-lint team. See:

https://github.com/golangci/golangci-lint/issues/2671#issuecomment-2310658099 and here:
https://github.com/golangci/golangci-lint/issues/1658#issuecomment-2312129214