### PR TITLE
Ensure that wasm_exec.js file is always copied from the GOROOT

### DIFF
--- a/magefiles/consts.go
+++ b/magefiles/consts.go
@@ -25,3 +25,8 @@ const WasmTestSuiteDir = "wasm-test-suite"
 const LegacyWasmTestSuiteDir = "legacy-wasm-test-suite"
 const ExamplesDir = "examples"
 const MagefilesDir = "magefiles"
+
+const GoRoot = "GOROOT" // GOROOT env var name
+const WasmExecJSPathMiscDir = "misc"
+const WasmExecJSPathWasmDir = "wasm"
+const WasmExecJS = "wasm_exec.js"

--- a/magefiles/gitcmd.go
+++ b/magefiles/gitcmd.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/magefile/mage/sh"
@@ -21,6 +22,28 @@ func gitDiffFiles() error {
 		cwd, _ := os.Getwd()
 		diff, _ := gitCmdCaptureOutput("diff")
 		return fmt.Errorf("The git repo is dirty. Where these files committed to the repository after `vugugen` and `go mod tidy` had been run?\ngit status output from dir: %s:\n%s\ndiff:\n%s\n", cwd, out, diff)
+	}
+	return err
+}
+
+func gitDiffFile(f string) error {
+	err := gitCmdV("diff", "--quiet", f) // --quiet surpresses all output - see "git hulp diff" so we don't need gitCmdCombinedOutput here
+	if err != nil {
+		// the diff failed so run it again but capture the diff - in this case the return is always nil
+		out, diffErr := gitCmdCaptureOutput("diff", f)
+		if diffErr != nil {
+			return fmt.Errorf("git diff %s failed with: %s\n", f, err)
+		}
+		// We have a difference between the GOROOT copy of wasm_exec.js and the local copy in teh repo.
+		// Ee have no idea if the local file is compatabel with the version of the Go compile rin use - and have no way to determine this
+		// until the wasm_exec.js is contains a version string that can be matched against the compiler.
+		// In order to ensure a successful run we MUST take the version that matched thee compile rin use i.e. the GOROOT copy will overright the repo copy (if any)
+		// In tis case we will emit a warning to indicates that the wasm_exec.js does not match the compiler verison in use.
+		log.Printf("WARNING There is a difference between the %s copy of %s and the local copy at %s", GoRoot, WasmExecJS, f)
+		log.Printf("WARNING The build process cannot tell which version of Go that the local file relates to because the Go team do not embed a version into %s\n", WasmExecJS)
+		log.Printf("WARNING Copying the %S version of %s as this file must match the compiler version in use.\n", GoRoot, WasmExecJS)
+		log.Printf("WARNING The file difference was:\n%s\n", out)
+		return nil
 	}
 	return err
 }

--- a/magefiles/gocmd.go
+++ b/magefiles/gocmd.go
@@ -43,6 +43,12 @@ func goBuildWithEnvs(envs map[string]string, binaryName, pkgName string) error {
 
 }
 
+// Get the GOROOT for the standard go compiler via go env
+// we need a tinygo version of this!
+func goGetGoRoot() (string, error) {
+	return goCmdCaptureOutput("env", GoRoot)
+}
+
 func buildLegacyWasmTestSuiteServer() error {
 	envs := map[string]string{
 		"CGO_ENABLED": "0",


### PR DESCRIPTION
The Go Wiki states:

Note: The same major Go version of the compiler and wasm_exec.js support file must be used together. That is, if main.wasm file is compiled using Go version 1.N, the corresponding wasm_exec.js file must also be copied from Go version 1.N. Other combinations are not supported.

See:
https://go.dev/wiki/WebAssembly

For the standard Go compiler ONLY this commit ensures that the above is true for modules under both the wasm-test-suite and examples directories.

It will also print a warning and a diff if a local repo copy of wasm_exec.js differs from the GOROOT version.

The warning states that the GOROOT version will be used i.e. the local copy will be overwritten. This is to ensure that the correct version of wasm_exec.js for the compiler version in use is used. The warning will not cause the built to fail.

The wasm_exec.js file does not contian any version information (e.g. as a comment) so it is impossible to also say if any repo version is older or newer than the Go compiler version in use. Regardless of this, the file must be overwritten with the correct compiler version.

Once/If any local wasm_exec.js files are removed from the repo, the check that produces the warning will have no effect. The change is therefore forward compatible.

A separate change will be required to support the tinygo compiler at a later date. The tinygo copy of wasm_exec.js is very different from the standard compiler version and is located at a different path under the tinygo root. However, the same versioning constrains apply.