### PR TITLE
Stop calling `go get golang.org/x/tools/cmd/goimports` in the GitHub Action file before running the `mage` based build

### DIFF
--- a/.github/workflows/go-oldstable.yml
+++ b/.github/workflows/go-oldstable.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         go-version: '${{ matrix.go }}'
 
-    - name: Install goinports
+    - name: Install goimports
       run: go install golang.org/x/tools/cmd/goimports@latest
 
     - name: Print Go version

--- a/.github/workflows/go-oldstable.yml
+++ b/.github/workflows/go-oldstable.yml
@@ -25,7 +25,7 @@ jobs:
         go-version: '${{ matrix.go }}'
 
     - name: Install goinports
-      run: go get golang.org/x/tools/cmd/goimports && go install golang.org/x/tools/cmd/goimports
+      run: go get golang.org/x/tools/cmd/goimports@latest && go install golang.org/x/tools/cmd/goimports@latest
 
     - name: Print Go version
       run: go version

--- a/.github/workflows/go-oldstable.yml
+++ b/.github/workflows/go-oldstable.yml
@@ -25,7 +25,7 @@ jobs:
         go-version: '${{ matrix.go }}'
 
     - name: Install goinports
-      run: go get golang.org/x/tools/cmd/goimports@latest && go install golang.org/x/tools/cmd/goimports@latest
+      run: go install golang.org/x/tools/cmd/goimports@latest
 
     - name: Print Go version
       run: go version

--- a/.github/workflows/go-stable.yml
+++ b/.github/workflows/go-stable.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         go-version: '${{ matrix.go }}'
 
-    - name: Install goinports
+    - name: Install goimports
       run: go install golang.org/x/tools/cmd/goimports@latest
 
     - name: Print Go version

--- a/.github/workflows/go-stable.yml
+++ b/.github/workflows/go-stable.yml
@@ -25,7 +25,7 @@ jobs:
         go-version: '${{ matrix.go }}'
 
     - name: Install goinports
-      run: go get golang.org/x/tools/cmd/goimports && go install golang.org/x/tools/cmd/goimports
+      run: go get golang.org/x/tools/cmd/goimports@latest && go install golang.org/x/tools/cmd/goimports@latest
 
     - name: Print Go version
       run: go version

--- a/.github/workflows/go-stable.yml
+++ b/.github/workflows/go-stable.yml
@@ -25,7 +25,7 @@ jobs:
         go-version: '${{ matrix.go }}'
 
     - name: Install goinports
-      run: go get golang.org/x/tools/cmd/goimports@latest && go install golang.org/x/tools/cmd/goimports@latest
+      run: go install golang.org/x/tools/cmd/goimports@latest
 
     - name: Print Go version
       run: go version

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -87,7 +87,7 @@ func Build() error {
 		return err
 	}
 	// install the vugufmt command by executing
-	err = goInstall("github.com/vugu/vugu/cmd/vugufmt")
+	err = goInstall("github.com/vugu/vugu/cmd/vugufmt@latest")
 	return err
 }
 


### PR DESCRIPTION
Since Go 1.18 calling `go get` will implicitly update the modules
`go.mod` file by adding the specified module and adding or updating any of
 its dependencies - including those used only for tests.
    
Since Go 1.18 go get only downloads the module into the module cache. It no longer
builds or installs the module. For that go install is needed.
    
We only want the `goimports` command executable installed, as it
can be called by the `vugufmt` tool. The correct way to do this is
therefore:
    
`go install golang.org/x/tools/cmd/goimports@latest`
    
The `@latest` tag puts `go install` into module aware mode and ensures that
the local go.mod file is not used or changed. See:
    
https://go.dev/ref/mod#go-install
    
In particular we do not what the `vugu` `go.mod` file to be updated
because of a dependency of `goimports` but we do want to ensure
`goimports` is installed.
    
The only way to acheve this is to drop the
`go get golang.org/x/tools/cmd/goimports`
 and only call
 `go install golang.org/x/tools/cmd/goimports@latest`
 instead.

The PR also ues the same `@latest` technique when installing `vugufmt` from the `magefile` to ensure the `vugu` `go.mod` is left unchanged when building and installing the `vugufmt` tool.

