### PR TITLE
Bump the dependencies of legacy-wasm-test-suite/test-020-vgform

### DIFF
--- a/legacy-wasm-test-suite/test-020-vgform/go.mod
+++ b/legacy-wasm-test-suite/test-020-vgform/go.mod
@@ -11,5 +11,5 @@ require (
 
 require (
 	github.com/vugu/xxhash v0.0.0-20191111030615-ed24d0179019 // indirect
-	golang.org/x/text v0.14.0 // indirect
+	golang.org/x/text v0.17.0 // indirect
 )


### PR DESCRIPTION
Bumping the verison of goimports brings in golang/x/text v0.17.0. This causes a version bump of golang/x/text used by legacy-wasm-test-suite/test-020-vgform from v0.14.0 to v0.17.0