### PR TITLE
Enable the tinygo compiler test now tinygo supports go 1.23

### DIFF
--- a/devutil/tinygo-compiler_test.go
+++ b/devutil/tinygo-compiler_test.go
@@ -10,8 +10,6 @@ import (
 )
 
 func TestTinygoCompiler(t *testing.T) {
-	// skip the test until we have go v1.23+ support.
-	t.Skip("TTestTinygoCompiler is skipped until the tinygo compiler supports Go v1.23+")
 
 	tmpDir, err := os.MkdirTemp("", "TestTinygoCompiler")
 	if err != nil {


### PR DESCRIPTION
(Re)Enable the tinygo compiler test now that tinygo supports go 1.23 as of tinygo v0.33.

See:

https://github.com/tinygo-org/tinygo/releases/tag/v0.33.0