### PR TITLE
Fix: add `wasm_exec.js` to the local git ignore file

### DIFF
--- a/examples/vg-if/.gitignore
+++ b/examples/vg-if/.gitignore
@@ -4,3 +4,6 @@
 # *.wasm - generated wasm files
 
 *.wasm
+
+# this should always be taken from the GOROOT on each build
+wasm_exec.js


### PR DESCRIPTION
wasm_exec.js shoudl always be copied from the GOROOT as part of the build porcess as it has to match the Go compiler version. So we want to ignore any local copies.