### PR TITLE
Oops: Fix a typo in the .gitignore in some of the examples

### DIFF
--- a/examples/compound-component/.gitignore
+++ b/examples/compound-component/.gitignore
@@ -5,5 +5,5 @@
 
 *.wasm
 
-# ignore wasm_exec.js as this shoudl be copied from the GOROOT by the build process
+# ignore wasm_exec.js as this should be copied from the GOROOT by the build process
 wasm_exec.js

--- a/examples/html-form/.gitignore
+++ b/examples/html-form/.gitignore
@@ -5,5 +5,5 @@
 
 *.wasm
 
-# ignore wasm_exec.js as this shoudl be copied from the GOROOT by the build process
+# ignore wasm_exec.js as this should be copied from the GOROOT by the build process
 wasm_exec.js

--- a/examples/vg-if/.gitignore
+++ b/examples/vg-if/.gitignore
@@ -4,3 +4,6 @@
 # *.wasm - generated wasm files
 
 *.wasm
+
+# ignore wasm_exec.js as this should be copied from the GOROOT by the build process
+wasm_exec.js


### PR DESCRIPTION
Fix: Corrects a typo in the .gitignore of soem of the examples.