### PR TITLE
Fix and rework vugu/js

### DIFF
--- a/js/helpers.go
+++ b/js/helpers.go
@@ -1,0 +1,49 @@
+//go:build js && wasm
+
+package js
+
+import sjs "syscall/js"
+
+// convertAnyToSJS converts any aliased value into its syscall/js counterpart.
+func convertAnyToSJS(arg any) any {
+	switch arg := arg.(type) {
+	case Value:
+		return sjs.Value(arg)
+	case Func:
+		return arg.f
+	}
+
+	return arg
+}
+
+// convertSliceToSJS takes a []any and converts every aliased value into its syscall/js counterpart.
+//
+// This is a bit dirty, as it may modify the given slice.
+func convertSliceToSJS(args []any) []any {
+	for i, arg := range args {
+		switch arg := arg.(type) {
+		case Value:
+			args[i] = sjs.Value(arg)
+		case Func:
+			args[i] = arg.f
+		}
+	}
+
+	return args
+}
+
+// convertMapToSJS takes a map[T]any and converts every aliased value into its syscall/js counterpart.
+//
+// This is a bit dirty, as it may modify the given map.
+func convertMapToSJS[T comparable](args map[T]any) map[T]any {
+	for k, arg := range args {
+		switch arg := arg.(type) {
+		case Value:
+			args[k] = sjs.Value(arg)
+		case Func:
+			args[k] = arg.f
+		}
+	}
+
+	return args
+}

--- a/js/impl-js_test.go
+++ b/js/impl-js_test.go
@@ -1,0 +1,718 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build js && wasm
+
+// To run these tests:
+//
+// - Install Node
+// - PATH="$PATH:$(go env GOROOT)/misc/wasm" GOOS=js GOARCH=wasm go test -timeout 30s -v
+//
+// See -exec in "go help test", and "go help run" for details.
+
+package js_test
+
+import (
+	"fmt"
+	"math"
+	"runtime"
+	"testing"
+
+	"github.com/vugu/vugu/js"
+	//"syscall/js"
+)
+
+var dummys = js.Global().Call("eval", `({
+	someBool: true,
+	someString: "abc\u1234",
+	someInt: 42,
+	someFloat: 42.123,
+	someArray: [41, 42, 43],
+	someDate: new Date(),
+	add: function(a, b) {
+		return a + b;
+	},
+	zero: 0,
+	stringZero: "0",
+	NaN: NaN,
+	emptyObj: {},
+	emptyArray: [],
+	Infinity: Infinity,
+	NegInfinity: -Infinity,
+	objNumber0: new Number(0),
+	objBooleanFalse: new Boolean(false),
+})`)
+
+//go:wasmexport testExport
+func testExport(a int32, b int64) int64 {
+	testExportCalled = true
+	// test stack growth
+	growStack(1000)
+	// force a goroutine switch
+	ch := make(chan int64)
+	go func() {
+		ch <- int64(a)
+		ch <- b
+	}()
+	return <-ch + <-ch
+}
+
+//go:wasmexport testExport0
+func testExport0() { // no arg or result (see issue 69584)
+	runtime.GC()
+}
+
+var testExportCalled bool
+
+func growStack(n int64) {
+	if n > 0 {
+		growStack(n - 1)
+	}
+}
+
+/*func TestWasmExport(t *testing.T) {
+	testExportCalled = false
+	a := int32(123)
+	b := int64(456)
+	want := int64(a) + b
+	if got := testCallExport(a, b); got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	if !testExportCalled {
+		t.Error("testExport not called")
+	}
+}*/
+
+func TestBool(t *testing.T) {
+	want := true
+	o := dummys.Get("someBool")
+	if got := o.Bool(); got != want {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+	dummys.Set("otherBool", want)
+	if got := dummys.Get("otherBool").Bool(); got != want {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+	if !dummys.Get("someBool").Equal(dummys.Get("someBool")) {
+		t.Errorf("same value not equal")
+	}
+}
+
+func TestString(t *testing.T) {
+	want := "abc\u1234"
+	o := dummys.Get("someString")
+	if got := o.String(); got != want {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+	dummys.Set("otherString", want)
+	if got := dummys.Get("otherString").String(); got != want {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+	if !dummys.Get("someString").Equal(dummys.Get("someString")) {
+		t.Errorf("same value not equal")
+	}
+
+	if got, want := js.Undefined().String(), "<undefined>"; got != want {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+	if got, want := js.Null().String(), "<null>"; got != want {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+	if got, want := js.ValueOf(true).String(), "<boolean: true>"; got != want {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+	if got, want := js.ValueOf(42.5).String(), "<number: 42.5>"; got != want {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+	if got, want := js.Global().Call("Symbol").String(), "<symbol>"; got != want {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+	if got, want := js.Global().String(), "<object>"; got != want {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+	if got, want := js.Global().Get("setTimeout").String(), "<function>"; got != want {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+}
+
+func TestInt(t *testing.T) {
+	want := 42
+	o := dummys.Get("someInt")
+	if got := o.Int(); got != want {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+	dummys.Set("otherInt", want)
+	if got := dummys.Get("otherInt").Int(); got != want {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+	if !dummys.Get("someInt").Equal(dummys.Get("someInt")) {
+		t.Errorf("same value not equal")
+	}
+	if got := dummys.Get("zero").Int(); got != 0 {
+		t.Errorf("got %#v, want %#v", got, 0)
+	}
+}
+
+func TestIntConversion(t *testing.T) {
+	testIntConversion(t, 0)
+	testIntConversion(t, 1)
+	testIntConversion(t, -1)
+	testIntConversion(t, 1<<20)
+	testIntConversion(t, -1<<20)
+	testIntConversion(t, 1<<40)
+	testIntConversion(t, -1<<40)
+	testIntConversion(t, 1<<60)
+	testIntConversion(t, -1<<60)
+}
+
+func testIntConversion(t *testing.T, want int) {
+	if got := js.ValueOf(want).Int(); got != want {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+}
+
+func TestFloat(t *testing.T) {
+	want := 42.123
+	o := dummys.Get("someFloat")
+	if got := o.Float(); got != want {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+	dummys.Set("otherFloat", want)
+	if got := dummys.Get("otherFloat").Float(); got != want {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+	if !dummys.Get("someFloat").Equal(dummys.Get("someFloat")) {
+		t.Errorf("same value not equal")
+	}
+}
+
+func TestObject(t *testing.T) {
+	if !dummys.Get("someArray").Equal(dummys.Get("someArray")) {
+		t.Errorf("same value not equal")
+	}
+
+	// An object and its prototype should not be equal.
+	proto := js.Global().Get("Object").Get("prototype")
+	o := js.Global().Call("eval", "new Object()")
+	if proto.Equal(o) {
+		t.Errorf("object equals to its prototype")
+	}
+}
+
+func TestFrozenObject(t *testing.T) {
+	o := js.Global().Call("eval", "(function () { let o = new Object(); o.field = 5; Object.freeze(o); return o; })()")
+	want := 5
+	if got := o.Get("field").Int(); want != got {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+}
+
+func TestEqual(t *testing.T) {
+	if !dummys.Get("someFloat").Equal(dummys.Get("someFloat")) {
+		t.Errorf("same float is not equal")
+	}
+	if !dummys.Get("emptyObj").Equal(dummys.Get("emptyObj")) {
+		t.Errorf("same object is not equal")
+	}
+	if dummys.Get("someFloat").Equal(dummys.Get("someInt")) {
+		t.Errorf("different values are not unequal")
+	}
+}
+
+func TestNaN(t *testing.T) {
+	if !dummys.Get("NaN").IsNaN() {
+		t.Errorf("JS NaN is not NaN")
+	}
+	if !js.ValueOf(math.NaN()).IsNaN() {
+		t.Errorf("Go NaN is not NaN")
+	}
+	if dummys.Get("NaN").Equal(dummys.Get("NaN")) {
+		t.Errorf("NaN is equal to NaN")
+	}
+}
+
+func TestUndefined(t *testing.T) {
+	if !js.Undefined().IsUndefined() {
+		t.Errorf("undefined is not undefined")
+	}
+	if !js.Undefined().Equal(js.Undefined()) {
+		t.Errorf("undefined is not equal to undefined")
+	}
+	if dummys.IsUndefined() {
+		t.Errorf("object is undefined")
+	}
+	if js.Undefined().IsNull() {
+		t.Errorf("undefined is null")
+	}
+	if dummys.Set("test", js.Undefined()); !dummys.Get("test").IsUndefined() {
+		t.Errorf("could not set undefined")
+	}
+}
+
+func TestNull(t *testing.T) {
+	if !js.Null().IsNull() {
+		t.Errorf("null is not null")
+	}
+	if !js.Null().Equal(js.Null()) {
+		t.Errorf("null is not equal to null")
+	}
+	if dummys.IsNull() {
+		t.Errorf("object is null")
+	}
+	if js.Null().IsUndefined() {
+		t.Errorf("null is undefined")
+	}
+	if dummys.Set("test", js.Null()); !dummys.Get("test").IsNull() {
+		t.Errorf("could not set null")
+	}
+	if dummys.Set("test", nil); !dummys.Get("test").IsNull() {
+		t.Errorf("could not set nil")
+	}
+}
+
+func TestLength(t *testing.T) {
+	if got := dummys.Get("someArray").Length(); got != 3 {
+		t.Errorf("got %#v, want %#v", got, 3)
+	}
+}
+
+func TestGet(t *testing.T) {
+	// positive cases get tested per type
+
+	expectValueError(t, func() {
+		dummys.Get("zero").Get("badField")
+	})
+}
+
+func TestSet(t *testing.T) {
+	// positive cases get tested per type
+
+	expectValueError(t, func() {
+		dummys.Get("zero").Set("badField", 42)
+	})
+}
+
+func TestDelete(t *testing.T) {
+	dummys.Set("test", 42)
+	dummys.Delete("test")
+	if dummys.Call("hasOwnProperty", "test").Bool() {
+		t.Errorf("property still exists")
+	}
+
+	expectValueError(t, func() {
+		dummys.Get("zero").Delete("badField")
+	})
+}
+
+func TestIndex(t *testing.T) {
+	if got := dummys.Get("someArray").Index(1).Int(); got != 42 {
+		t.Errorf("got %#v, want %#v", got, 42)
+	}
+
+	expectValueError(t, func() {
+		dummys.Get("zero").Index(1)
+	})
+}
+
+func TestSetIndex(t *testing.T) {
+	dummys.Get("someArray").SetIndex(2, 99)
+	if got := dummys.Get("someArray").Index(2).Int(); got != 99 {
+		t.Errorf("got %#v, want %#v", got, 99)
+	}
+
+	expectValueError(t, func() {
+		dummys.Get("zero").SetIndex(2, 99)
+	})
+}
+
+func TestCall(t *testing.T) {
+	var i int64 = 40
+	if got := dummys.Call("add", i, 2).Int(); got != 42 {
+		t.Errorf("got %#v, want %#v", got, 42)
+	}
+	if got := dummys.Call("add", js.Global().Call("eval", "40"), 2).Int(); got != 42 {
+		t.Errorf("got %#v, want %#v", got, 42)
+	}
+
+	expectPanic(t, func() {
+		dummys.Call("zero")
+	})
+	expectValueError(t, func() {
+		dummys.Get("zero").Call("badMethod")
+	})
+}
+
+func TestInvoke(t *testing.T) {
+	var i int64 = 40
+	if got := dummys.Get("add").Invoke(i, 2).Int(); got != 42 {
+		t.Errorf("got %#v, want %#v", got, 42)
+	}
+
+	expectValueError(t, func() {
+		dummys.Get("zero").Invoke()
+	})
+}
+
+func TestNew(t *testing.T) {
+	if got := js.Global().Get("Array").New(42).Length(); got != 42 {
+		t.Errorf("got %#v, want %#v", got, 42)
+	}
+
+	expectValueError(t, func() {
+		dummys.Get("zero").New()
+	})
+}
+
+func TestInstanceOf(t *testing.T) {
+	someArray := js.Global().Get("Array").New()
+	if got, want := someArray.InstanceOf(js.Global().Get("Array")), true; got != want {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+	if got, want := someArray.InstanceOf(js.Global().Get("Function")), false; got != want {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+}
+
+func TestType(t *testing.T) {
+	if got, want := js.Undefined().Type(), js.TypeUndefined; got != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+	if got, want := js.Null().Type(), js.TypeNull; got != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+	if got, want := js.ValueOf(true).Type(), js.TypeBoolean; got != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+	if got, want := js.ValueOf(0).Type(), js.TypeNumber; got != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+	if got, want := js.ValueOf(42).Type(), js.TypeNumber; got != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+	if got, want := js.ValueOf("test").Type(), js.TypeString; got != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+	if got, want := js.Global().Get("Symbol").Invoke("test").Type(), js.TypeSymbol; got != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+	if got, want := js.Global().Get("Array").New().Type(), js.TypeObject; got != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+	if got, want := js.Global().Get("Array").Type(), js.TypeFunction; got != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+}
+
+type object = map[string]any
+type array = []any
+
+func TestValueOf(t *testing.T) {
+	a := js.ValueOf(array{0, array{0, 42, 0}, 0})
+	if got := a.Index(1).Index(1).Int(); got != 42 {
+		t.Errorf("got %v, want %v", got, 42)
+	}
+
+	o := js.ValueOf(object{"x": object{"y": 42}})
+	if got := o.Get("x").Get("y").Int(); got != 42 {
+		t.Errorf("got %v, want %v", got, 42)
+	}
+}
+
+func TestZeroValue(t *testing.T) {
+	var v js.Value
+	if !v.IsUndefined() {
+		t.Error("zero js.Value is not js.Undefined()")
+	}
+}
+
+func TestFuncOf(t *testing.T) {
+	c := make(chan struct{})
+	cb := js.FuncOf(func(this js.Value, args []js.Value) any {
+		if got := args[0].Int(); got != 42 {
+			t.Errorf("got %#v, want %#v", got, 42)
+		}
+		c <- struct{}{}
+		return nil
+	})
+	defer cb.Release()
+	js.Global().Call("setTimeout", cb, 0, 42)
+	<-c
+}
+
+func TestInvokeFunction(t *testing.T) {
+	called := false
+	cb := js.FuncOf(func(this js.Value, args []js.Value) any {
+		cb2 := js.FuncOf(func(this js.Value, args []js.Value) any {
+			called = true
+			return 42
+		})
+		defer cb2.Release()
+		return cb2.Invoke()
+	})
+	defer cb.Release()
+	if got := cb.Invoke().Int(); got != 42 {
+		t.Errorf("got %#v, want %#v", got, 42)
+	}
+	if !called {
+		t.Error("function not called")
+	}
+}
+
+func TestInterleavedFunctions(t *testing.T) {
+	c1 := make(chan struct{})
+	c2 := make(chan struct{})
+
+	js.Global().Get("setTimeout").Invoke(js.FuncOf(func(this js.Value, args []js.Value) any {
+		c1 <- struct{}{}
+		<-c2
+		return nil
+	}), 0)
+
+	<-c1
+	c2 <- struct{}{}
+	// this goroutine is running, but the callback of setTimeout did not return yet, invoke another function now
+	f := js.FuncOf(func(this js.Value, args []js.Value) any {
+		return nil
+	})
+	f.Invoke()
+}
+
+func ExampleFuncOf() {
+	var cb js.Func
+	cb = js.FuncOf(func(this js.Value, args []js.Value) any {
+		fmt.Println("button clicked")
+		cb.Release() // release the function if the button will not be clicked again
+		return nil
+	})
+	js.Global().Get("document").Call("getElementById", "myButton").Call("addEventListener", "click", cb)
+}
+
+// See
+// - https://developer.mozilla.org/en-US/docs/Glossary/Truthy
+// - https://stackoverflow.com/questions/19839952/all-falsey-values-in-javascript/19839953#19839953
+// - http://www.ecma-international.org/ecma-262/5.1/#sec-9.2
+func TestTruthy(t *testing.T) {
+	want := true
+	for _, key := range []string{
+		"someBool", "someString", "someInt", "someFloat", "someArray", "someDate",
+		"stringZero", // "0" is truthy
+		"add",        // functions are truthy
+		"emptyObj", "emptyArray", "Infinity", "NegInfinity",
+		// All objects are truthy, even if they're Number(0) or Boolean(false).
+		"objNumber0", "objBooleanFalse",
+	} {
+		if got := dummys.Get(key).Truthy(); got != want {
+			t.Errorf("%s: got %#v, want %#v", key, got, want)
+		}
+	}
+
+	want = false
+	if got := dummys.Get("zero").Truthy(); got != want {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+	if got := dummys.Get("NaN").Truthy(); got != want {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+	if got := js.ValueOf("").Truthy(); got != want {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+	if got := js.Null().Truthy(); got != want {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+	if got := js.Undefined().Truthy(); got != want {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+}
+
+func expectValueError(t *testing.T, fn func()) {
+	defer func() {
+		err := recover()
+		if _, ok := err.(*js.ValueError); !ok {
+			t.Errorf("expected *js.ValueError, got %T", err)
+		}
+	}()
+	fn()
+}
+
+func expectPanic(t *testing.T, fn func()) {
+	defer func() {
+		err := recover()
+		if err == nil {
+			t.Errorf("expected panic")
+		}
+	}()
+	fn()
+}
+
+var copyTests = []struct {
+	srcLen  int
+	dstLen  int
+	copyLen int
+}{
+	{5, 3, 3},
+	{3, 5, 3},
+	{0, 0, 0},
+}
+
+func TestCopyBytesToGo(t *testing.T) {
+	for _, tt := range copyTests {
+		t.Run(fmt.Sprintf("%d-to-%d", tt.srcLen, tt.dstLen), func(t *testing.T) {
+			src := js.Global().Get("Uint8Array").New(tt.srcLen)
+			if tt.srcLen >= 2 {
+				src.SetIndex(1, 42)
+			}
+			dst := make([]byte, tt.dstLen)
+
+			if got, want := js.CopyBytesToGo(dst, src), tt.copyLen; got != want {
+				t.Errorf("copied %d, want %d", got, want)
+			}
+			if tt.dstLen >= 2 {
+				if got, want := int(dst[1]), 42; got != want {
+					t.Errorf("got %d, want %d", got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestCopyBytesToJS(t *testing.T) {
+	for _, tt := range copyTests {
+		t.Run(fmt.Sprintf("%d-to-%d", tt.srcLen, tt.dstLen), func(t *testing.T) {
+			src := make([]byte, tt.srcLen)
+			if tt.srcLen >= 2 {
+				src[1] = 42
+			}
+			dst := js.Global().Get("Uint8Array").New(tt.dstLen)
+
+			if got, want := js.CopyBytesToJS(dst, src), tt.copyLen; got != want {
+				t.Errorf("copied %d, want %d", got, want)
+			}
+			if tt.dstLen >= 2 {
+				if got, want := dst.Index(1).Int(), 42; got != want {
+					t.Errorf("got %d, want %d", got, want)
+				}
+			}
+		})
+	}
+}
+
+/*func TestGarbageCollection(t *testing.T) {
+	before := js.JSGo.Get("_values").Length()
+	for i := 0; i < 1000; i++ {
+		_ = js.Global().Get("Object").New().Call("toString").String()
+		runtime.GC()
+	}
+	after := js.JSGo.Get("_values").Length()
+	if after-before > 500 {
+		t.Errorf("garbage collection ineffective")
+	}
+}*/
+
+// This table is used for allocation tests. We expect a specific allocation
+// behavior to be seen, depending on the number of arguments applied to various
+// JavaScript functions.
+// Note: All JavaScript functions return a JavaScript array, which will cause
+// one allocation to be created to track the Value.gcPtr for the Value finalizer.
+var allocTests = []struct {
+	argLen   int // The number of arguments to use for the syscall
+	expected int // The expected number of allocations
+}{
+	// For less than or equal to 16 arguments, we expect 1 allocation:
+	// - makeValue new(ref)
+	{0, 1},
+	{2, 1},
+	{15, 1},
+	{16, 1},
+	// For greater than 16 arguments, we expect 3 allocation:
+	// - makeValue: new(ref)
+	// - makeArgSlices: argVals = make([]Value, size)
+	// - makeArgSlices: argRefs = make([]ref, size)
+	{17, 3},
+	{32, 3},
+	{42, 3},
+}
+
+// TestCallAllocations ensures the correct allocation profile for Value.Call
+func TestCallAllocations(t *testing.T) {
+	for _, test := range allocTests {
+		args := make([]any, test.argLen)
+
+		tmpArray := js.Global().Get("Array").New(0)
+		numAllocs := testing.AllocsPerRun(100, func() {
+			tmpArray.Call("concat", args...)
+		})
+
+		if numAllocs != float64(test.expected) {
+			t.Errorf("got numAllocs %#v, want %#v", numAllocs, test.expected)
+		}
+	}
+}
+
+// TestInvokeAllocations ensures the correct allocation profile for Value.Invoke
+func TestInvokeAllocations(t *testing.T) {
+	for _, test := range allocTests {
+		args := make([]any, test.argLen)
+
+		tmpArray := js.Global().Get("Array").New(0)
+		concatFunc := tmpArray.Get("concat").Call("bind", tmpArray)
+		numAllocs := testing.AllocsPerRun(100, func() {
+			concatFunc.Invoke(args...)
+		})
+
+		if numAllocs != float64(test.expected) {
+			t.Errorf("got numAllocs %#v, want %#v", numAllocs, test.expected)
+		}
+	}
+}
+
+// TestNewAllocations ensures the correct allocation profile for Value.New
+func TestNewAllocations(t *testing.T) {
+	arrayConstructor := js.Global().Get("Array")
+
+	for _, test := range allocTests {
+		args := make([]any, test.argLen)
+
+		numAllocs := testing.AllocsPerRun(100, func() {
+			arrayConstructor.New(args...)
+		})
+
+		if numAllocs != float64(test.expected) {
+			t.Errorf("got numAllocs %#v, want %#v", numAllocs, test.expected)
+		}
+	}
+}
+
+// BenchmarkDOM is a simple benchmark which emulates a webapp making DOM operations.
+// It creates a div, and sets its id. Then searches by that id and sets some data.
+// Finally it removes that div.
+func BenchmarkDOM(b *testing.B) {
+	document := js.Global().Get("document")
+	if document.IsUndefined() {
+		b.Skip("Not a browser environment. Skipping.")
+	}
+	const data = "someString"
+	for i := 0; i < b.N; i++ {
+		div := document.Call("createElement", "div")
+		div.Call("setAttribute", "id", "myDiv")
+		document.Get("body").Call("appendChild", div)
+		myDiv := document.Call("getElementById", "myDiv")
+		myDiv.Set("innerHTML", data)
+
+		if got, want := myDiv.Get("innerHTML").String(), data; got != want {
+			b.Errorf("got %s, want %s", got, want)
+		}
+		document.Get("body").Call("removeChild", div)
+	}
+}
+
+func TestGlobal(t *testing.T) {
+	ident := js.FuncOf(func(this js.Value, args []js.Value) any {
+		return args[0]
+	})
+	defer ident.Release()
+
+	if got := ident.Invoke(js.Global()); !got.Equal(js.Global()) {
+		t.Errorf("got %#v, want %#v", got, js.Global())
+	}
+}

--- a/js/impl-nonjs.go
+++ b/js/impl-nonjs.go
@@ -1,46 +1,158 @@
-//go:build !js
-// +build !js
+//go:build !js || !wasm
 
 package js
 
-import "errors"
+import (
+	"errors"
+)
 
 var errNotImpl = errors.New("js not implemented")
 
-// Error placeholder for syscall/js
+// ######################
+// # syscall/js func.go #
+// ######################
+
+// Func is a wrapped Go function to be called by JavaScript.
+//
+// This is a syscall/js placeholder.
+type Func struct {
+	Value // the JavaScript function that invokes the Go function
+}
+
+// FuncOf returns a function to be used by JavaScript.
+//
+// The Go function fn is called with the value of JavaScript's "this" keyword and the
+// arguments of the invocation. The return value of the invocation is
+// the result of the Go function mapped back to JavaScript according to ValueOf.
+//
+// Invoking the wrapped Go function from JavaScript will
+// pause the event loop and spawn a new goroutine.
+// Other wrapped functions which are triggered during a call from Go to JavaScript
+// get executed on the same goroutine.
+//
+// As a consequence, if one wrapped function blocks, JavaScript's event loop
+// is blocked until that function returns. Hence, calling any async JavaScript
+// API, which requires the event loop, like fetch (http.Client), will cause an
+// immediate deadlock. Therefore a blocking function should explicitly start a
+// new goroutine.
+//
+// Func.Release must be called to free up resources when the function will not be invoked any more.
+//
+// This is a syscall/js placeholder.
+func FuncOf(fn func(this Value, args []Value) any) Func {
+	panic(errNotImpl)
+}
+
+// Release frees up resources allocated for the function.
+// The function must not be invoked after calling Release.
+// It is allowed to call Release while the function is still running.
+//
+// This is a syscall/js placeholder.
+func (c Func) Release() {}
+
+// ####################
+// # syscall/js js.go #
+// ####################
+
+// Value represents a JavaScript value. The zero value is the JavaScript value "undefined".
+// Values can be checked for equality with the Equal method.
+//
+// This is a syscall/js placeholder.
+type Value struct {
+	_ [0]func() // uncomparable; to make == not compile
+}
+
+// Error wraps a JavaScript error.
+//
+// This is a syscall/js placeholder.
 type Error struct {
 	Value
 }
 
-// Error placeholder for syscall/js
+// Error implements the error interface.
+//
+// This is a syscall/js placeholder.
 func (e Error) Error() string {
 	return errNotImpl.Error()
 }
 
-// Func placeholder for syscall/js
-type Func struct {
-	Value
+// Equal reports whether v and w are equal according to JavaScript's === operator.
+//
+// This is a syscall/js placeholder.
+func (v Value) Equal(w Value) bool {
+	return true
 }
 
-// FuncOf placeholder for syscall/js
-func FuncOf(fn func(Value, []Value) interface{}) Func {
-	// making this panic for now, although I can see some utility in allowing this
-	// and then they just never get called, will see...
-	panic(errNotImpl)
-	// return Func{}
+// Undefined returns the JavaScript value "undefined".
+//
+// This is a syscall/js placeholder.
+func Undefined() Value {
+	return Value{}
 }
 
-// Release placeholder for syscall/js
-func (c Func) Release() {
-	// nop
+// IsUndefined reports whether v is the JavaScript value "undefined".
+//
+// This is a syscall/js placeholder.
+func (v Value) IsUndefined() bool {
+	return true
 }
 
-// Type placeholder for syscall/js
+// Null returns the JavaScript value "null".
+//
+// This is a syscall/js placeholder.
+func Null() Value {
+	return Value{}
+}
+
+// Null returns the JavaScript value "null".
+//
+// This is a syscall/js placeholder.
+func (v Value) IsNull() bool {
+	return false
+}
+
+// IsNaN reports whether v is the JavaScript value "NaN".
+//
+// This is a syscall/js placeholder.
+func (v Value) IsNaN() bool {
+	return false
+}
+
+// Global returns the JavaScript global object, usually "window" or "global".
+//
+// This is a syscall/js placeholder.
+func Global() Value {
+	return Value{}
+}
+
+// ValueOf returns x as a JavaScript value:
+//
+//	| Go                     | JavaScript             |
+//	| ---------------------- | ---------------------- |
+//	| js.Value               | [its value]            |
+//	| js.Func                | function               |
+//	| nil                    | null                   |
+//	| bool                   | boolean                |
+//	| integers and floats    | number                 |
+//	| string                 | string                 |
+//	| []interface{}          | new array              |
+//	| map[string]interface{} | new object             |
+//
+// Panics if x is not one of the expected types.
+//
+// This is a syscall/js placeholder.
+func ValueOf(x any) Value {
+	return Value{}
+}
+
+// Type represents the JavaScript type of a Value.
+//
+// This is a syscall/js placeholder.
 type Type int
 
-// Placeholder for syscall/js
+// This is a syscall/js placeholder.
 const (
-	TypeUndefined Type = iota
+	TypeUndefined = iota
 	TypeNull
 	TypeBoolean
 	TypeNumber
@@ -50,147 +162,173 @@ const (
 	TypeFunction
 )
 
-// String placeholder for syscall/js
+// This is a syscall/js placeholder.
 func (t Type) String() string {
 	return "undefined"
 }
 
-// Undefined placeholder for syscall/js
-func Undefined() Value {
-	return Value{}
+// Type returns the JavaScript type of the value v. It is similar to JavaScript's typeof operator,
+// except that it returns TypeNull instead of TypeObject for null.
+//
+// This is a syscall/js placeholder.
+func (v Value) Type() Type {
+	return TypeUndefined
 }
 
-// Null placeholder for syscall/js
-func Null() Value {
-	return Value{}
+// Get returns the JavaScript property p of value v.
+// It panics if v is not a JavaScript object.
+//
+// This is a syscall/js placeholder.
+func (v Value) Get(p string) Value {
+	panic(errNotImpl)
 }
 
-// Global placeholder for syscall/js
-func Global() Value {
-	return Value{}
+// Set sets the JavaScript property p of value v to ValueOf(x).
+// It panics if v is not a JavaScript object.
+//
+// This is a syscall/js placeholder.
+func (v Value) Set(p string, x any) {
+	panic(errNotImpl)
 }
 
-// ValueOf placeholder for syscall/js
-func ValueOf(x interface{}) Value {
-	return Value{}
+// Delete deletes the JavaScript property p of value v.
+// It panics if v is not a JavaScript object.
+//
+// This is a syscall/js placeholder.
+func (v Value) Delete(p string) {
+	panic(errNotImpl)
 }
 
-// CopyBytesToGo placeholder for syscall/js
-func CopyBytesToGo(dst []byte, src Value) int {
-	return 0
+// Index returns JavaScript index i of value v.
+// It panics if v is not a JavaScript object.
+//
+// This is a syscall/js placeholder.
+func (v Value) Index(i int) Value {
+	panic(errNotImpl)
 }
 
-// CopyBytesToJS placeholder for syscall/js
-func CopyBytesToJS(dst Value, src []byte) int {
-	return 0
+// SetIndex sets the JavaScript index i of value v to ValueOf(x).
+// It panics if v is not a JavaScript object.
+//
+// This is a syscall/js placeholder.
+func (v Value) SetIndex(i int, x any) {
+	panic(errNotImpl)
 }
 
-// // TypedArray placeholder for syscall/js
-// type TypedArray struct {
-// 	Value
-// }
+// Length returns the JavaScript property "length" of v.
+// It panics if v is not a JavaScript object.
+//
+// This is a syscall/js placeholder.
+func (v Value) Length() int {
+	panic(errNotImpl)
+}
 
-// // TypedArrayOf placeholder for syscall/js
-// func TypedArrayOf(slice interface{}) TypedArray {
-// 	return TypedArray{}
-// }
+// Call does a JavaScript call to the method m of value v with the given arguments.
+// It panics if v has no method m.
+// The arguments get mapped to JavaScript values according to the ValueOf function.
+//
+// This is a syscall/js placeholder.
+func (v Value) Call(m string, args ...any) Value {
+	panic(errNotImpl)
+}
 
-// // Release placeholder for syscall/js
-// func (a TypedArray) Release() {
-// 	// nop
-// }
+// Invoke does a JavaScript call of the value v with the given arguments.
+// It panics if v is not a JavaScript function.
+// The arguments get mapped to JavaScript values according to the ValueOf function.
+//
+// This is a syscall/js placeholder.
+func (v Value) Invoke(args ...any) Value {
+	panic(errNotImpl)
+}
 
-// ValueError placeholder for syscall/js
+// New uses JavaScript's "new" operator with value v as constructor and the given arguments.
+// It panics if v is not a JavaScript function.
+// The arguments get mapped to JavaScript values according to the ValueOf function.
+//
+// This is a syscall/js placeholder.
+func (v Value) New(args ...any) Value {
+	panic(errNotImpl)
+}
+
+// Float returns the value v as a float64.
+// It panics if v is not a JavaScript number.
+//
+// This is a syscall/js placeholder.
+func (v Value) Float() float64 {
+	panic(errNotImpl)
+}
+
+// Int returns the value v truncated to an int.
+// It panics if v is not a JavaScript number.
+//
+// This is a syscall/js placeholder.
+func (v Value) Int() int {
+	panic(errNotImpl)
+}
+
+// Bool returns the value v as a bool.
+// It panics if v is not a JavaScript boolean.
+//
+// This is a syscall/js placeholder.
+func (v Value) Bool() bool {
+	panic(errNotImpl)
+}
+
+// Truthy returns the JavaScript "truthiness" of the value v. In JavaScript,
+// false, 0, "", null, undefined, and NaN are "falsy", and everything else is
+// "truthy". See https://developer.mozilla.org/en-US/docs/Glossary/Truthy.
+//
+// This is a syscall/js placeholder.
+func (v Value) Truthy() bool {
+	return false
+}
+
+// String returns the value v as a string.
+// String is a special case because of Go's String method convention. Unlike the other getters,
+// it does not panic if v's Type is not TypeString. Instead, it returns a string of the form "<T>"
+// or "<T: V>" where T is v's type and V is a string representation of v's value.
+//
+// This is a syscall/js placeholder.
+func (v Value) String() string {
+	return "<undefined>"
+}
+
+// InstanceOf reports whether v is an instance of type t according to JavaScript's instanceof operator.
+//
+// This is a syscall/js placeholder.
+func (v Value) InstanceOf(t Value) bool {
+	return false
+}
+
+// A ValueError occurs when a Value method is invoked on
+// a Value that does not support it. Such cases are documented
+// in the description of each method.
+//
+// This is a syscall/js placeholder.
 type ValueError struct {
 	Method string
 	Type   Type
 }
 
-// Error placeholder for syscall/js
+// This is a syscall/js placeholder.
 func (e *ValueError) Error() string {
 	return errNotImpl.Error()
 }
 
-// Wrapper placeholder for syscall/js
-type Wrapper interface {
-	JSValue() Value
-}
-
-// Value placeholder for syscall/js
-type Value struct {
-	stub uint64 //nolint:golint,unused
-}
-
-// JSValue placeholder for syscall/js
-func (v Value) JSValue() Value {
-	return v
-}
-
-// Type placeholder for syscall/js
-func (v Value) Type() Type {
-	return TypeUndefined
-}
-
-func (v Value) Get(p string) Value {
-	return Undefined()
-}
-
-func (v Value) Set(p string, x interface{}) {
+// CopyBytesToGo copies bytes from src to dst.
+// It panics if src is not a Uint8Array or Uint8ClampedArray.
+// It returns the number of bytes copied, which will be the minimum of the lengths of src and dst.
+//
+// This is a syscall/js placeholder.
+func CopyBytesToGo(dst []byte, src Value) int {
 	panic(errNotImpl)
 }
 
-func (v Value) Index(i int) Value {
-	return Undefined()
-}
-
-func (v Value) SetIndex(i int, x interface{}) {
+// CopyBytesToJS copies bytes from src to dst.
+// It panics if dst is not a Uint8Array or Uint8ClampedArray.
+// It returns the number of bytes copied, which will be the minimum of the lengths of src and dst.
+//
+// This is a syscall/js placeholder.
+func CopyBytesToJS(dst Value, src []byte) int {
 	panic(errNotImpl)
-}
-
-func (v Value) Length() int {
-	return 0
-}
-
-func (v Value) Call(m string, args ...interface{}) Value {
-	panic(errNotImpl)
-}
-
-func (v Value) Invoke(args ...interface{}) Value {
-	panic(errNotImpl)
-}
-
-func (v Value) New(args ...interface{}) Value {
-	return Undefined()
-}
-
-func (v Value) Float() float64 {
-	return 0
-}
-
-func (v Value) Int() int {
-	return 0
-}
-
-func (v Value) Bool() bool {
-	return false
-}
-
-func (v Value) Truthy() bool {
-	return false
-}
-
-func (v Value) String() string {
-	return ""
-}
-
-func (v Value) InstanceOf(t Value) bool {
-	return false
-}
-
-func (v Value) IsUndefined() bool {
-	return true
-}
-
-func (v Value) IsNull() bool {
-	return false
 }


### PR DESCRIPTION
`vugu/js` is now in sync with `syscall/js`.
The following changes and fixes were applied:

- Original comments were added, so most editors will show useful info, no matter if placeholder or alias types are used.
- Moved `fixArgsToSjs` into `helpers.go` and renamed it to `convertAnyToSJS`
- Fix missing conversion of return values in `FuncOf`
- Use go type aliasing where possible
- Add missing `Equal` method to `Value`
- Add missing `IsNaN` method to `Value`
- Fix slice and map handling of `ValueOf`
- Fix missing conversion in `Set` method of `Value`
- Fix missing conversion in `SetIndex` method of `Value`
- Make nonjs `Value` uncomparable
- Add missing nonjs placeholder types and functions
- Make behavior of the placeholder types and functions more consistent with the description in `doc.go`

This makes #205 and #207 obsolete. And should fix #328 and #266.

I fully tested it by using the original `syscall/js` tests. Also, it may be good to move some/all of the tests to the wasm test suite, and add some more tests related to slices and maps containing `vugu/js` Value objects...

@owenwaller I haven't included any wasm unit test, as you are already working on one.