### PR TITLE
Copy the wasm_exec.js file from the correct location pre and post go1.24

### DIFF
--- a/magefiles/consts.go
+++ b/magefiles/consts.go
@@ -26,7 +26,14 @@ const LegacyWasmTestSuiteDir = "legacy-wasm-test-suite"
 const ExamplesDir = "examples"
 const MagefilesDir = "magefiles"
 
-const GoRoot = "GOROOT" // GOROOT env var name
-const WasmExecJSPathMiscDir = "misc"
+const GoRoot = "GOROOT"       // GOROOT env var name
+const GoVersion = "GOVERSION" // GOVERSION env var name
+// The Go 1.24 release notes state that the "wasm_exec.js1" file has been moved from:
+// $GOROOT/misc/wasm to $GOROOT/lib/wasm.
+// While we still build with a pre go1.24 versions we ned to account for the different paths
+const WasmExecJSPathMiscDir = "misc" // used for pre go1.24
+const WasmExecJSPathLibDir = "lib"   // used for go1.24 and onwards
 const WasmExecJSPathWasmDir = "wasm"
 const WasmExecJS = "wasm_exec.js"
+
+const Go1_24_0SemVer = "v1.24.0"

--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -3,3 +3,5 @@ module github.com/vugu/vugu/magefiles
 go 1.22.3
 
 require github.com/magefile/mage v1.15.0
+
+require golang.org/x/mod v0.23.0

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,2 +1,4 @@
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
+golang.org/x/mod v0.23.0 h1:Zb7khfcRGKk+kqfxFaP5tZqCnDZMjC5VtUBs87Hr6QM=
+golang.org/x/mod v0.23.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=

--- a/magefiles/gocmd.go
+++ b/magefiles/gocmd.go
@@ -49,6 +49,21 @@ func goGetGoRoot() (string, error) {
 	return goCmdCaptureOutput("env", GoRoot)
 }
 
+// return the go version as a semvar string
+func goGetSemVer() (string, error) {
+	goVersion, err := goCmdCaptureOutput("env", GoVersion)
+	if err != nil {
+		return "", err
+	}
+	// the goVersion looks like:
+	// go1.24.0
+	// But we need it in the form
+	// v1.24.0
+	// for comparison
+	goVersion = strings.ReplaceAll(goVersion, "go", "v")
+	return goVersion, nil
+}
+
 func buildLegacyWasmTestSuiteServer() error {
 	envs := map[string]string{
 		"CGO_ENABLED": "0",

--- a/magefiles/modulehandler.go
+++ b/magefiles/modulehandler.go
@@ -5,11 +5,13 @@ package main
 import (
 	"bufio"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/magefile/mage/sh"
+	"golang.org/x/mod/semver"
 )
 
 func buildAndTestModule(module moduleData, withGeneratedFileCheck bool) error {
@@ -235,7 +237,24 @@ func copyWasmExecJSFromGoRoot(module moduleData) error {
 	if err != nil {
 		return err
 	}
-	fullWasmExecPath := filepath.Join(goRoot, WasmExecJSPathMiscDir, WasmExecJSPathWasmDir, WasmExecJS)
+	// which version of Go are we, as the path to the wasm_exec.js is different pre go1.24
+	goSemVer, err := goGetSemVer()
+	if err != nil {
+		return err
+	}
+	log.Printf("Go Sem Ver: %s\n", goSemVer)
+	log.Printf("Sem Ver Constant: %s\n", Go1_24_0SemVer)
+	var fullWasmExecPath string
+	if semver.Compare(goSemVer, Go1_24_0SemVer) < 0 {
+		// we are pre go 1.24.0
+		log.Printf("Pre Go 1.24.0 - using misc\n")
+		fullWasmExecPath = filepath.Join(goRoot, WasmExecJSPathMiscDir, WasmExecJSPathWasmDir, WasmExecJS)
+	} else {
+		// we are Go1.24.0 or greater
+		log.Printf("Go 1.24.0 or later- using lib\n")
+		fullWasmExecPath = filepath.Join(goRoot, WasmExecJSPathLibDir, WasmExecJSPathWasmDir, WasmExecJS)
+	}
+
 	// create a fie reader on the wasm_exec.js file
 	wasmExecJs, err := os.Open(fullWasmExecPath)
 	if err != nil {


### PR DESCRIPTION
Go 1.24 changed the location of the wasm_exec.js file from:

$GOROOT/misc/wasm
to
$GOROOT/lib/wasm

See the relase notes for go1.24.

As we currently still build using go1.23 (the current oldstable release) the magefiles need to be updated to account for this change.

This change can be removed once go.1.25 arrives in Aug 2025. At that point both the stable and oldstable releases will used the newer $GOROOT/lib/wasm directory.