### PR TITLE
Fix the staticrender ValueOf test

### DIFF
--- a/staticrender/renderer-static_test.go
+++ b/staticrender/renderer-static_test.go
@@ -107,6 +107,8 @@ comp1 in the house
 			infiles: map[string]string{
 				"root.vugu": `<div id="testing"><div id="syscalljs" vg-content='c.ValueOf()'></div></div>`,
 				"root.go": `
+// this test is built natively, so uses the limited vugu/js package
+// we expect attempting to call js.Value.Get(p string) to panic as we are not running on a GOOS=js && GOARCH=wasm platform 
 package main
 
 import (
@@ -130,13 +132,13 @@ func (c *Root) ValueOf() (s string) {
 }
 
 func (c *Root) panicingFunc() {
-	date := js.Global().Get("Date")
+	date := js.Global().Get("Date") // the Get call will FAIL as we are building this test is NOT being built for GOOS=js GOARCH-wasm its being built natively.
 	timeEndValue := date.New(time.Now().UnixMilli())
 	js.ValueOf(timeEndValue)
 }`,
 			},
 			outReMatch: []string{
-				`<div id="testing"><div id="syscalljs">syscall/js passed</div>`,
+				`<div id="testing"><div id="syscalljs">js not implemented</div>`,
 			},
 			outReNotMatch: []string{`Panic`},
 		},


### PR DESCRIPTION
The staticrender ValueOf tests will only ever be executed on a GOOS=!js || GOARCH=!wasm platform i.e, on the native platform only.

Because the test uses the limited, but cross platform vugu/js nonjs implementation of the package we expect the test to panic.

The test has now been updated to expect the panic string.

If this test were to fail in the future it would indicate that the wrong vugu/js implementation has been called.