### PR TITLE
Disable building the legacy-wasm-test-suite via the AllGithubAction t…

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -69,7 +69,23 @@ func AllGitHubAction() error {
 		TestWasmWithGeneratedFilesCheck,
 		Examples,
 		StopLocalNginxForExamples,
-		TestLegacyWasm,
+		// With Go 1.24.x the location of the wasm_exec.js file has changed.
+		// We do not wan to update the legacy test suite - we want to eventually remove it - so we have not updated the
+		// test code to reflect this change.
+		// In addition if we use Go 1.23.x then the latest version of tinygo (v0.36+) wil panic with:
+		//    --- FAIL: Test012Router/tinygo/Docker (20.85s)
+		//		panic: TinygoCompiler: build error: exit status 1; cmd.args: [docker run --rm -v /home/owen/go/pkg/mod:/gomodcache -e GOMODCACHE=/gomodcache -v /home/owen/.cache/tinygo:/tinygocache -e GOCACHE=/tinygocache -v /:/src -v /tmp/:/out -e HOME=/tmp --user=1000 -w /src/home/owen/src/vugu/legacy-wasm-test-suite/test-012-router tinygo/tinygo:latest tinygo build -o /out/WasmCompiler226958135 -target=wasm .], full output:
+		//		/usr/local/go/src/crypto/internal/sysrand/rand_js.go:13:22: //go:wasmimport gojs runtime.getRandomData: unsupported parameter type []byte
+		//		[recovered]
+		//		panic: TinygoCompiler: build error: exit status 1; cmd.args: [docker run --rm -v /home/owen/go/pkg/mod:/gomodcache -e GOMODCACHE=/gomodcache -v /home/owen/.cache/tinygo:/tinygocache -e GOCACHE=/tinygocache -v /:/src -v /tmp/:/out -e HOME=/tmp --user=1000 -w /src/home/owen/src/vugu/legacy-wasm-test-suite/test-012-router tinygo/tinygo:latest tinygo build -o /out/WasmCompiler226958135 -target=wasm .], full output:
+		///usr/local/go/src/crypto/internal/sysrand/rand_js.go:13:22: //go:wasmimport gojs runtime.getRandomData: unsupported parameter type []byte
+		//
+		// Given that we want to remove the legacy test suite this is not worth fixing.
+		// However Issues #278 and #279 now urgently need fixed:
+		// https://github.com/vugu/vugu/issues/279
+		// https://github.com/vugu/vugu/issues/278
+		//
+		//TestLegacyWasm,
 	)
 	return nil
 }


### PR DESCRIPTION
…arget

The AllGithubAction magefile target no longer builds the legacy-wasm-test-suite.

Given that location of the wasm_exec.js file has changed with Go 1.24.x and that the most recent timygo compiler v0.36+ no longer builds the legacy test suite the building of the test suite has been disabled.

This now means that Issues #278 and #279 need to be resolved urgently.

The replacement wasm-test-suite includes all of the tests and still builds.

See the code comment for more details.

The legacy wasm test suite can still be built explicitly by calling:

mage -v testLegacyWasm

You may need both a older version of Go (pre 1.24) and a older version of Tinygo (pre 0.36) before this will work however.