### PR TITLE
✨ Quality: Data race and concurrent access to non-thread-safe rand.Rand

### DIFF
--- a/comp-key.go
+++ b/comp-key.go
@@ -24,12 +24,7 @@ func MakeCompKeyIDTimeHash(t time.Time, b []byte) uint64 {
 	return MakeCompKeyID(t, uint32(h.Sum64()))
 }
 
-var compKeyRand *rand.Rand
-
 // MakeCompKeyIDNowRand generates a value for CompKey.ID using the newer v2 version of the math/rand package
 func MakeCompKeyIDNowRand() uint64 {
-	if compKeyRand == nil {
-		compKeyRand = rand.New(rand.NewPCG(uint64(time.Now().UnixNano()), uint64(time.Now().UnixNano())))
-	}
-	return compKeyRand.Uint64()
+	return rand.Uint64()
 }


### PR DESCRIPTION
## ✨ Code Quality

### Problem
The `MakeCompKeyIDNowRand` function lazily initializes a global `compKeyRand` instance of `math/rand/v2.Rand` and calls `Uint64()` on it. 
There are two critical concurrency bugs here:
1. The lazy initialization (`if compKeyRand == nil`) is not protected by a mutex, causing a data race where multiple goroutines might overwrite the generator.
2. More importantly, `math/rand/v2.Rand` is explicitly documented as **not safe for concurrent use**. Calling `Uint64()` concurrently from multiple goroutines will cause internal state corruption, data races, and can lead to panics or duplicate component IDs being generated.

Since `math/rand/v2` provides a globally shared, automatically seeded, and concurrency-safe generator, you can simply use the package-level `rand.Uint64()` function instead of managing your own instance.


**Severity**: `high`
**File**: `comp-key.go`

### Solution
// Remove the global compKeyRand variable entirely and update the function:

// MakeCompKeyIDNowRand generates a value for CompKey.ID using the newer v2 version of the math/rand package
func MakeCompKeyIDNowRand() uint64 {
	return rand.Uint64()
}


### Changes
- `comp-key.go` (modified)

### Testing
- [x] Existing tests pass
- [x] Manual review completed
- [x] No new warnings/errors introduced

---


---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>


Closes #377