### PR TITLE
Add support for a project bootstrap command - `vugu init MODULENAME`

### DIFF
--- a/cmd/vugu/gen/gen.go
+++ b/cmd/vugu/gen/gen.go
@@ -17,8 +17,8 @@ var (
 // This function is a direct copy of cmd/vugugen/vugugen.go, no
 // functionality has been changed.
 func Gen(ctx context.Context, cmd *cli.Command) error {
-	// we need to get the argumets from the command as a slice.
-	// The only argumnt would be the directory to run in.
+	// we need to get the arguments from the command as a slice.
+	// The only argument would be the directory to run in.
 	args := cmd.Args().Slice()
 
 	// default to current directory

--- a/cmd/vugu/initialise/initialise.go
+++ b/cmd/vugu/initialise/initialise.go
@@ -1,0 +1,244 @@
+package initialise
+
+import (
+	"bufio"
+	"context"
+	"embed"
+	_ "embed"
+	"fmt"
+	"html/template"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/urfave/cli/v3"
+	"github.com/vugu/vugu/cmd/vugu/sh"
+)
+
+type InitOpts struct {
+	Dir string
+	// The title of the html page
+	PageTitle string
+	// The directory where the wasm_exec.js file is located on the web server.
+	// Any training slash will be stripped.
+	WasmExecJSDir string
+	// The name of the div id i.e. <div id="..."> which contains the wasm binary
+	MountPoint string
+	// The directory where the wasm binary is located on the web server.
+	// Any training slash will be stripped.
+	WasmMainDir string
+	// The name of the wasm binary
+	WasmBinaryName string
+	// the name of the Go source file that containts the main function
+	WasmGoFilename string
+	// The full import path of the package that contains the base/root type. This will be used by a go import so must be valid package import path
+	RootStructPkgImportPath string
+	// The name of package that containts the the base/root type. The package name will be used by a go import so must be valid package name
+	RootStructPkgAlias string
+	// The name of the base/root type. This struct is the man entry point for the wasm code. This must be a valid, exported type in the RootStructPkg
+	RootStructType string
+	// Do not generate an index.html at the root of the module directory if true
+	NoIndex bool
+	//Do not generate a main_wasm.go at teh root if the module directory is true
+	NoMain bool
+}
+
+func (d *InitOpts) cleanTemplateData() {
+	// clean the directories - we need to remove any trailing slash
+	d.WasmExecJSDir = filepath.Clean(d.WasmExecJSDir)
+	// clean can result in a empty path which Clean returns as "." or if a root a "/", but we really want the empty path, so flip this back
+	if d.WasmExecJSDir == "." || d.WasmExecJSDir == string(os.PathSeparator) {
+		d.WasmExecJSDir = ""
+	}
+	d.WasmMainDir = filepath.Clean(d.WasmMainDir)
+	if d.WasmMainDir == "." || d.WasmMainDir == string(os.PathSeparator) {
+		d.WasmMainDir = ""
+	}
+	d.WasmBinaryName = filepath.Base(d.WasmBinaryName)
+	// base can return ".", ".." or "/" i.e. os.PathSeparator. If we get any of these we want the default name
+	if d.WasmBinaryName == "." || d.WasmBinaryName == ".." || d.WasmBinaryName == string(os.PathSeparator) {
+		d.WasmBinaryName = defaultWasmBinaryName
+	}
+}
+
+const templateDirName = "templates"
+const indexHTMLTmplName = templateDirName + "/" + "index.html.tmpl"
+const mainWasmTmplName = templateDirName + "/" + "main_wasm.go.tmpl"
+const rootDotGoTmplName = templateDirName + "/" + "root.go.tmpl"
+const rootDotVuguName = templateDirName + "/" + "root.vugu"
+
+const defaultWasmBinaryName = "main.wasm"
+
+var (
+	Opts InitOpts
+	//go:embed templates
+	content embed.FS
+)
+
+func Initialise(ctx context.Context, cmd *cli.Command) error {
+	// we need to get the arguments from the command as a slice.
+	// The only argument would be the module name to create.
+	args := cmd.Args().Slice()
+
+	if len(args) != 1 {
+		return fmt.Errorf("init: too many arguments. Expected one but found %d.", len(args))
+	}
+
+	// if the RootStructAlias is set then the RootStructPkgImportPath must also be set
+	if Opts.RootStructPkgAlias != "" && Opts.RootStructPkgImportPath == "" {
+		return fmt.Errorf("The --rootstructpkgalis flag was set to %q but the --rootstructpkgimportpath was not set. Both flags are required is a package is to be aliased.", Opts.RootStructPkgAlias)
+	}
+
+	moduleName := args[0]
+	fmt.Printf("ModuleName: %q\n", args[0])
+	fmt.Printf("Dir Option %q\n", Opts.Dir)
+
+	// CD to the dir specified
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	defer os.Chdir(cwd) // ignore an error
+
+	err = os.Chdir(Opts.Dir)
+	if err != nil {
+		return err
+	}
+
+	Opts.cleanTemplateData()
+
+	// create the index.html
+	if Opts.NoIndex == false { // use ==false test rather than !NoIndex to make the indent clear. The default is false.
+		err = createIndexHtml(content, Opts)
+		if err != nil {
+			return err
+		}
+	}
+
+	// create the main_wasm.go in the package
+	if Opts.NoMain == false { // use ==false test rather than !NoIndex to make the indent clear. The default is false.
+		err = createMainWasmDotGo(content, Opts)
+		if err != nil {
+			return err
+		}
+	}
+
+	// create the root.vugu file
+	// if a user has supplied an import path for the root component we assume they know what they are doing and that the root
+	// components source (both .go and .vugu) are in the package
+	if Opts.RootStructPkgImportPath == "" { // No import prth set so we can generate a root.vugu and root.go files
+		err = createRootDotVugu(content, Opts)
+		if err != nil {
+			return err
+		}
+		// create the root.go file
+		err = createRootDotGo(content, Opts)
+		if err != nil {
+			return err
+		}
+	}
+	// run "go mod init moduleName
+	err = sh.RunV("go", "mod", "init", moduleName)
+
+	return err
+}
+
+func createIndexHtml(fs fs.FS, opts InitOpts) error {
+	tmpl, err := template.ParseFS(fs, indexHTMLTmplName)
+	if err != nil {
+		return err
+	}
+	indexHTML, err := os.Create(opts.Dir + "/index.html")
+	if err != nil {
+		return err
+	}
+	defer indexHTML.Close()
+	err = tmpl.Execute(indexHTML, opts)
+	if err != nil {
+		return err
+	}
+	err = indexHTML.Sync() // ensure we flush to disk
+	return err
+}
+
+func createMainWasmDotGo(fs fs.FS, opts InitOpts) error {
+	tmpl, err := template.ParseFS(fs, mainWasmTmplName)
+	if err != nil {
+		return err
+	}
+	mainWasm, err := os.Create(opts.Dir + "/" + opts.WasmGoFilename) // how do we ensure this is a .go filename?
+	if err != nil {
+		return err
+	}
+	defer mainWasm.Close()
+
+	// we must strip any training slash from the RootStructPkg name.
+	// if its not an empty string we can use filepath.Clean to do this for us.
+
+	if opts.RootStructPkgImportPath != "" {
+		// if its an empty string the root struct is in the main package
+		opts.RootStructPkgImportPath = filepath.Clean(opts.RootStructPkgImportPath)
+	}
+	// now we need the just the package name from the full import path.
+	// we can use filepath.Base for this
+	fmt.Printf("Before %q\n", opts.RootStructPkgAlias)
+
+	if opts.RootStructPkgAlias == "" {
+		// the package has not been aliased so we need to get the package name from the import path
+		opts.RootStructPkgAlias = filepath.Base(opts.RootStructPkgImportPath)
+		// make sure we are not left with "." as Base does if opts.RootStructPkgImportPath was an empty string
+		if opts.RootStructPkgAlias == "." {
+			opts.RootStructPkgAlias = ""
+		}
+	}
+	fmt.Printf("After %q\n", opts.RootStructPkgAlias)
+
+	err = tmpl.Execute(mainWasm, opts)
+	if err != nil {
+		return err
+	}
+	err = mainWasm.Sync() // ensure we flush to disk
+	return err
+}
+
+func createRootDotVugu(fs fs.FS, opts InitOpts) error {
+	rootDotVuguSrc, err := fs.Open(rootDotVuguName)
+	if err != nil {
+		return err
+	}
+	defer rootDotVuguSrc.Close()
+	r := bufio.NewReader(rootDotVuguSrc)
+
+	rootDotVuguDest, err := os.Create(opts.Dir + "/" + opts.RootStructType + ".vugu")
+	if err != nil {
+		return err
+	}
+	defer rootDotVuguDest.Close()
+	w := bufio.NewWriter(rootDotVuguDest)
+	_, err = io.Copy(w, r)
+	if err != nil {
+		return err
+	}
+	err = rootDotVuguDest.Sync() // ensure we flush to disk
+	return err
+}
+
+func createRootDotGo(fs fs.FS, opts InitOpts) error {
+	tmpl, err := template.ParseFS(fs, rootDotGoTmplName)
+	if err != nil {
+		return err
+	}
+	rootDotGo, err := os.Create(opts.Dir + "/" + opts.RootStructType + ".go")
+	if err != nil {
+		return err
+	}
+	defer rootDotGo.Close()
+
+	err = tmpl.Execute(rootDotGo, opts)
+	if err != nil {
+		return err
+	}
+	err = rootDotGo.Sync() // ensure we flush to disk
+	return err
+}

--- a/cmd/vugu/initialise/initialise.go
+++ b/cmd/vugu/initialise/initialise.go
@@ -92,33 +92,39 @@ func Initialise(ctx context.Context, cmd *cli.Command) error {
 
 	moduleName := args[0]
 	fmt.Printf("ModuleName: %q\n", args[0])
-	fmt.Printf("Dir Option %q\n", Opts.Dir)
+	return doInitialise(ctx, moduleName, Opts)
+}
+
+func doInitialise(ctx context.Context, moduleName string, opts InitOpts) error {
+	// Opts is a package level variable
+	fmt.Printf("Dir Option %q\n", opts.Dir)
 
 	// CD to the dir specified
 	cwd, err := os.Getwd()
 	if err != nil {
 		return err
 	}
+	fmt.Printf("cwd: %s\n", cwd)
 	defer os.Chdir(cwd) // ignore an error
 
-	err = os.Chdir(Opts.Dir)
+	err = os.Chdir(opts.Dir)
 	if err != nil {
 		return err
 	}
 
-	Opts.cleanTemplateData()
+	opts.cleanTemplateData()
 
 	// create the index.html
-	if Opts.NoIndex == false { // use ==false test rather than !NoIndex to make the indent clear. The default is false.
-		err = createIndexHtml(content, Opts)
+	if opts.NoIndex == false { // use ==false test rather than !NoIndex to make the indent clear. The default is false.
+		err = createIndexHtml(content, opts)
 		if err != nil {
 			return err
 		}
 	}
 
 	// create the main_wasm.go in the package
-	if Opts.NoMain == false { // use ==false test rather than !NoIndex to make the indent clear. The default is false.
-		err = createMainWasmDotGo(content, Opts)
+	if opts.NoMain == false { // use ==false test rather than !NoIndex to make the indent clear. The default is false.
+		err = createMainWasmDotGo(content, opts)
 		if err != nil {
 			return err
 		}
@@ -127,13 +133,13 @@ func Initialise(ctx context.Context, cmd *cli.Command) error {
 	// create the root.vugu file
 	// if a user has supplied an import path for the root component we assume they know what they are doing and that the root
 	// components source (both .go and .vugu) are in the package
-	if Opts.RootStructPkgImportPath == "" { // No import prth set so we can generate a root.vugu and root.go files
-		err = createRootDotVugu(content, Opts)
+	if opts.RootStructPkgImportPath == "" { // No import prth set so we can generate a root.vugu and root.go files
+		err = createRootDotVugu(content, opts)
 		if err != nil {
 			return err
 		}
 		// create the root.go file
-		err = createRootDotGo(content, Opts)
+		err = createRootDotGo(content, opts)
 		if err != nil {
 			return err
 		}

--- a/cmd/vugu/initialise/initialise_test.go
+++ b/cmd/vugu/initialise/initialise_test.go
@@ -1,10 +1,19 @@
 package initialise
 
-import "testing"
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 func TestCleanTemplateData(t *testing.T) {
 	// fill the template
-	d := IndexHTMLData{}
+	d := newInitOpts()
 
 	// WasmExecJSDir tests
 	d.WasmExecJSDir = "/end/in/slash/"
@@ -120,5 +129,337 @@ func TestCleanTemplateData(t *testing.T) {
 	if d.WasmBinaryName != defaultWasmBinaryName {
 		t.Fatalf("Failed to return defaultWasmBinaryName when WasmMainDir was an empty string. Returned %q", d.WasmBinaryName)
 	}
+
+}
+
+func newInitOpts() InitOpts {
+	return InitOpts{
+		Dir:                     ".",
+		PageTitle:               "pagetitle",
+		WasmExecJSDir:           "",
+		MountPoint:              "mountpoint",
+		WasmMainDir:             "",
+		WasmBinaryName:          "main.wasm",
+		WasmGoFilename:          "main_wasm.go",
+		RootStructPkgImportPath: "",
+		RootStructPkgAlias:      "",
+		RootStructType:          "Root",
+		NoIndex:                 false,
+		NoMain:                  false,
+	}
+}
+
+func createTestDir(t *testing.T) string {
+	t.Helper()
+	d, err := os.MkdirTemp("", "vugu_init_test_") // put the dir under os.TempDir()
+	if err != nil {
+		t.Fatalf("Failed to create temp directory. %s", err)
+	}
+	return d
+}
+
+func removeTestDir(d string, t *testing.T) {
+	t.Helper()
+	err := os.RemoveAll(d)
+	if err != nil {
+		t.Fatalf("Failed to remove temp directory %s. %s", d, err)
+	}
+}
+
+func runInitialise(opts InitOpts, t *testing.T) {
+	t.Helper()
+	err := doInitialise(context.Background(), "dummyModule", opts)
+	if err != nil {
+		t.Fatalf("Failed to initialise. %s", err)
+	}
+}
+
+type initOptsDummy struct {
+	InitOpts
+}
+
+func (o *initOptsDummy) checkFilesAreGenerated(path string, d fs.DirEntry, err error) error {
+	// the generated file name should be one of
+	var rootGoFileName string
+	var rootVuguFileName string
+	if o.RootStructType != "Root" {
+		rootGoFileName = strings.ToLower(o.RootStructType) + ".go"
+		rootVuguFileName = strings.ToLower(o.RootStructType) + ".vugu"
+	}
+	if !d.IsDir() {
+		switch d.Name() {
+		case "index.html":
+			// we need to check the contents of the index.html
+			return o.checkIndexHtmlContents(d.Name())
+		case o.WasmGoFilename:
+			return o.checkWasmGoContents(d.Name())
+		case rootGoFileName:
+			return o.checkRootGoContents(d.Name())
+		case rootVuguFileName:
+			return nil
+		}
+	}
+	return nil // should return a dir
+}
+
+func (o *initOptsDummy) checkIndexHtmlContents(filename string) error {
+	// open the file
+	b, err := os.ReadFile(o.Dir + "/" + filename)
+	if err != nil {
+		return err
+	}
+	// the file should contain the page title
+	title := "<title>" + o.PageTitle + "</title>"
+	found := bytes.Contains(b, []byte(title))
+	if !found {
+		return fmt.Errorf("Could not find PageTitle (%q) in the index.html searched for %q", o.PageTitle, title)
+	}
+
+	// check the mount point
+	mp := "<div id=" + o.MountPoint + "\">" // note we only check for the div
+	found = bytes.Contains(b, []byte(mp))
+	if !found {
+		return fmt.Errorf("Could not find MontPoint (%q) in the index.html searched for %q", o.MountPoint, mp)
+	}
+
+	// check the file contains the main wasm file
+	binaryName := "fetch(\"" + o.WasmMainDir + "/" + o.WasmBinaryName + "\""
+	found = bytes.Contains(b, []byte(binaryName))
+	if !found {
+		return fmt.Errorf("Could not find binary name (%q) in the index.html searched for %q", binaryName, binaryName)
+	}
+
+	// check the file contains the wasm js dir, where the wasm_exec.js is stored - the wasm-exec.js must come form the Go distribution
+	wasmExecJSDir := "<script src=\"" + o.WasmExecJSDir + "/wasm_exec.js\"></script>"
+	found = bytes.Contains(b, []byte(wasmExecJSDir))
+	if !found {
+		return fmt.Errorf("Could not find wasm_exec.js directory (%q) in the index.html searched for %q", o.WasmExecJSDir, wasmExecJSDir)
+	}
+	return nil
+}
+
+func (o *initOptsDummy) checkWasmGoContents(filename string) error {
+	// open the file
+	b, err := os.ReadFile(o.Dir + "/" + filename)
+	if err != nil {
+		return err
+	}
+	// check the mount point
+	mp := "mountPoint := \"#\" + " + o.MountPoint // the paces are significant as this is matching a generated go variable declaration
+	found := bytes.Contains(b, []byte(mp))
+	if !found {
+		return fmt.Errorf("Could not find Mount Point (%q) in the %s searched for %q", o.MountPoint, o.WasmGoFilename, mp)
+	}
+
+	// check the import line (with and without an alias)
+	var imp string
+	if o.RootStructPkgAlias != "" {
+		imp = o.RootStructPkgAlias + " " + o.RootStructPkgImportPath + "\"" + o.RootStructPkgImportPath + "\""
+	}
+	if o.RootStructPkgImportPath != "" {
+		imp = "\"" + o.RootStructPkgImportPath + "\""
+	}
+	found = bytes.Contains(b, []byte(imp))
+	if !found {
+		return fmt.Errorf("Could not find import (%q) in the %s searched for %q", imp, o.WasmGoFilename, imp)
+	}
+
+	// check the root builder
+	var rb string
+	if o.RootStructPkgAlias != "" {
+		rb = "&" + o.RootStructPkgImportPath + "." + o.RootStructType + "{}"
+	} else {
+		rb = "&" + o.RootStructType + "{}"
+	}
+	found = bytes.Contains(b, []byte(rb))
+	if !found {
+		return fmt.Errorf("Could not find RootBuilder (%q) in the %s searched for %q", rb, o.WasmGoFilename, rb)
+	}
+	return nil
+}
+
+func (o *initOptsDummy) checkRootGoContents(filename string) error {
+	// open the file
+	b, err := os.ReadFile(o.Dir + "/" + filename)
+	if err != nil {
+		return err
+	}
+
+	var rootGoFileName string
+	if o.RootStructType != "Root" {
+		rootGoFileName = strings.ToLower(o.RootStructType) + ".go"
+	}
+	// check the struct definition
+	sd := "type " + o.RootStructType + " struct"
+	found := bytes.Contains(b, []byte(sd))
+	if !found {
+		return fmt.Errorf("Could not find root struct (%q) declaration in the %s searched for %q", o.RootStructPkgAlias, rootGoFileName, sd)
+	}
+	return nil
+}
+
+func TestInitiaiseDefaults(t *testing.T) {
+
+	o := newInitOpts()
+	opts := initOptsDummy{o}
+	opts.Dir = createTestDir(t)
+	t.Cleanup(func() { removeTestDir(opts.Dir, t) })
+
+	runInitialise(opts.InitOpts, t)
+
+	// check we have what we expect.
+	filepath.WalkDir(opts.Dir, opts.checkFilesAreGenerated)
+
+}
+
+func TestInitiaiseRootStructType(t *testing.T) {
+
+	o := newInitOpts()
+	opts := initOptsDummy{o}
+	opts.Dir = createTestDir(t)
+	opts.RootStructType = "Banana"
+	t.Cleanup(func() { removeTestDir(opts.Dir, t) })
+
+	runInitialise(opts.InitOpts, t)
+
+	// check we have what we expect.
+	filepath.WalkDir(opts.Dir, opts.checkFilesAreGenerated)
+
+}
+
+func TestInitiaiseWasmBinaryName(t *testing.T) {
+
+	o := newInitOpts()
+	opts := initOptsDummy{o}
+	opts.Dir = createTestDir(t)
+	opts.RootStructType = "Banana"
+	opts.WasmBinaryName = "goldfish.wasm"
+	t.Cleanup(func() { removeTestDir(opts.Dir, t) })
+
+	runInitialise(opts.InitOpts, t)
+
+	// check we have what we expect.
+	filepath.WalkDir(opts.Dir, opts.checkFilesAreGenerated)
+
+}
+
+func TestInitiaiseWasmGoFilename(t *testing.T) {
+
+	o := newInitOpts()
+	opts := initOptsDummy{o}
+	opts.Dir = createTestDir(t)
+	opts.RootStructType = "Banana"
+	opts.WasmBinaryName = "goldfish.wasm"
+	opts.WasmGoFilename = "cherry.go"
+	t.Cleanup(func() { removeTestDir(opts.Dir, t) })
+
+	runInitialise(opts.InitOpts, t)
+
+	// check we have what we expect.
+	filepath.WalkDir(opts.Dir, opts.checkFilesAreGenerated)
+
+}
+
+func TestInitiaiseWasmMainDir(t *testing.T) {
+
+	o := newInitOpts()
+	opts := initOptsDummy{o}
+	opts.Dir = createTestDir(t)
+	opts.RootStructType = "Banana"
+	opts.WasmBinaryName = "goldfish.wasm"
+	opts.WasmGoFilename = "cherry.go"
+	opts.WasmMainDir = "root_dir"
+	t.Cleanup(func() { removeTestDir(opts.Dir, t) })
+
+	runInitialise(opts.InitOpts, t)
+
+	// check we have what we expect.
+	filepath.WalkDir(opts.Dir, opts.checkFilesAreGenerated)
+
+}
+
+func TestInitiaisePageTitle(t *testing.T) {
+
+	o := newInitOpts()
+	opts := initOptsDummy{o}
+	opts.Dir = createTestDir(t)
+	opts.RootStructType = "Banana"
+	opts.WasmBinaryName = "goldfish.wasm"
+	opts.WasmGoFilename = "cherry.go"
+	opts.WasmMainDir = "root_dir"
+	opts.PageTitle = "This pages does nto exist!"
+
+	t.Cleanup(func() { removeTestDir(opts.Dir, t) })
+
+	runInitialise(opts.InitOpts, t)
+
+	// check we have what we expect.
+	filepath.WalkDir(opts.Dir, opts.checkFilesAreGenerated)
+
+}
+
+func TestInitiaiseMountPoint(t *testing.T) {
+
+	o := newInitOpts()
+	opts := initOptsDummy{o}
+	opts.Dir = createTestDir(t)
+	opts.RootStructType = "Banana"
+	opts.WasmBinaryName = "goldfish.wasm"
+	opts.WasmGoFilename = "cherry.go"
+	opts.WasmMainDir = "root_dir"
+	opts.PageTitle = "This pages does nto exist!"
+	opts.MountPoint = "This_is_not_a_Mount_Point"
+
+	t.Cleanup(func() { removeTestDir(opts.Dir, t) })
+
+	runInitialise(opts.InitOpts, t)
+
+	// check we have what we expect.
+	filepath.WalkDir(opts.Dir, opts.checkFilesAreGenerated)
+
+}
+
+func TestInitiaiseRootStructImportPath(t *testing.T) {
+
+	o := newInitOpts()
+	opts := initOptsDummy{o}
+	opts.Dir = createTestDir(t)
+	opts.RootStructType = "Banana"
+	opts.WasmBinaryName = "goldfish.wasm"
+	opts.WasmGoFilename = "cherry.go"
+	opts.WasmMainDir = "root_dir"
+	opts.PageTitle = "This pages does nto exist!"
+	opts.MountPoint = "This_is_not_a_Mount_Point"
+	opts.RootStructPkgImportPath = "github.com/junk/thingy"
+
+	t.Cleanup(func() { removeTestDir(opts.Dir, t) })
+
+	runInitialise(opts.InitOpts, t)
+
+	// check we have what we expect.
+	filepath.WalkDir(opts.Dir, opts.checkFilesAreGenerated)
+
+}
+
+func TestInitiaiseRootStructImportPathAlias(t *testing.T) {
+
+	o := newInitOpts()
+	opts := initOptsDummy{o}
+	opts.Dir = createTestDir(t)
+	opts.RootStructType = "Banana"
+	opts.WasmBinaryName = "goldfish.wasm"
+	opts.WasmGoFilename = "cherry.go"
+	opts.WasmMainDir = "root_dir"
+	opts.PageTitle = "This pages does nto exist!"
+	opts.MountPoint = "This_is_not_a_Mount_Point"
+	opts.RootStructPkgImportPath = "github.com/junk/thingy"
+	opts.RootStructPkgAlias = "silly_me"
+
+	t.Cleanup(func() { removeTestDir(opts.Dir, t) })
+
+	runInitialise(opts.InitOpts, t)
+
+	// check we have what we expect.
+	filepath.WalkDir(opts.Dir, opts.checkFilesAreGenerated)
 
 }

--- a/cmd/vugu/initialise/initialise_test.go
+++ b/cmd/vugu/initialise/initialise_test.go
@@ -1,0 +1,124 @@
+package initialise
+
+import "testing"
+
+func TestCleanTemplateData(t *testing.T) {
+	// fill the template
+	d := IndexHTMLData{}
+
+	// WasmExecJSDir tests
+	d.WasmExecJSDir = "/end/in/slash/"
+	d.cleanTemplateData()
+
+	if d.WasmExecJSDir != "/end/in/slash" {
+		t.Fatal("Failed to remove training slash from \"/end/in/slash/\"")
+	}
+
+	d.WasmExecJSDir = ""
+	d.cleanTemplateData()
+
+	if d.WasmExecJSDir != "" {
+		t.Fatalf("Failed to return an empty string when WasmExecJSDir is empty. Returned %q", d.WasmExecJSDir)
+	}
+
+	d.WasmExecJSDir = "."
+	d.cleanTemplateData()
+
+	if d.WasmExecJSDir != "" {
+		t.Fatalf("Failed to return empty string when WasmExecJSDir was a period. Returned %q", d.WasmExecJSDir)
+	}
+
+	d.WasmExecJSDir = ".."
+	d.cleanTemplateData()
+
+	if d.WasmExecJSDir != ".." {
+		t.Fatalf("Failed to leave unchanged when WasmExecJSDir was a .. Returned %q", d.WasmExecJSDir)
+	}
+
+	d.WasmExecJSDir = "/"
+	d.cleanTemplateData()
+
+	if d.WasmExecJSDir != "" {
+		t.Fatalf("Failed to return empty string when WasmExecJSDir was a /. Returned %q", d.WasmExecJSDir)
+	}
+
+	// WasmMainDir tests
+	d.WasmMainDir = "/end/in/slash/"
+	d.cleanTemplateData()
+
+	if d.WasmMainDir != "/end/in/slash" {
+		t.Fatal("Failed to remove training slash from \"/end/in/slash/\"")
+	}
+
+	d.WasmMainDir = ""
+	d.cleanTemplateData()
+
+	if d.WasmMainDir != "" {
+		t.Fatalf("Failed to return an empty string when WasmMainDir is empty. Returned %q", d.WasmMainDir)
+	}
+
+	d.WasmMainDir = "."
+	d.cleanTemplateData()
+
+	if d.WasmMainDir != "" {
+		t.Fatalf("Failed to return empty string when WasmMainDir was a period. Returned %q", d.WasmMainDir)
+	}
+
+	d.WasmMainDir = ".."
+	d.cleanTemplateData()
+
+	if d.WasmMainDir != ".." {
+		t.Fatalf("Failed to leave unchanged when WasmMainDir was a .. Returned %q", d.WasmMainDir)
+	}
+
+	d.WasmMainDir = "/"
+	d.cleanTemplateData()
+
+	if d.WasmMainDir != "" {
+		t.Fatalf("Failed to return empty string when WasmMainDir was a /. Returned %q", d.WasmMainDir)
+	}
+
+	// WasmBinaryName tests
+	d.WasmBinaryName = "/main.js/"
+	d.cleanTemplateData()
+
+	if d.WasmBinaryName != "main.js" {
+		t.Fatal("Failed to remove training slash from \"/main.js/\"")
+	}
+
+	d.WasmBinaryName = "main.js/"
+	d.cleanTemplateData()
+
+	if d.WasmBinaryName != "main.js" {
+		t.Fatal("Failed to remove training slash from \"main.js/\"")
+	}
+
+	d.WasmBinaryName = "."
+	d.cleanTemplateData()
+
+	if d.WasmBinaryName != defaultWasmBinaryName {
+		t.Fatalf("Failed to return defaultWasmBinaryName when WasmMainDir was a period. Returned %q", d.WasmBinaryName)
+	}
+
+	d.WasmBinaryName = ".."
+	d.cleanTemplateData()
+
+	if d.WasmBinaryName != defaultWasmBinaryName {
+		t.Fatalf("Failed to return defaultWasmBinaryName WasmMainDir was a .. Returned %q", d.WasmBinaryName)
+	}
+
+	d.WasmBinaryName = "/"
+	d.cleanTemplateData()
+
+	if d.WasmBinaryName != defaultWasmBinaryName {
+		t.Fatalf("Failed to return defaultWasmBinaryName when WasmMainDir was a /. Returned %q", d.WasmBinaryName)
+	}
+
+	d.WasmBinaryName = ""
+	d.cleanTemplateData()
+
+	if d.WasmBinaryName != defaultWasmBinaryName {
+		t.Fatalf("Failed to return defaultWasmBinaryName when WasmMainDir was an empty string. Returned %q", d.WasmBinaryName)
+	}
+
+}

--- a/cmd/vugu/initialise/templates/index.html.tmpl
+++ b/cmd/vugu/initialise/templates/index.html.tmpl
@@ -1,0 +1,31 @@
+<!doctype html>
+	<html>
+		<head>
+			<title>{{ .PageTitle }}</title>
+			<meta charset="utf-8"/>
+			<script src="https://cdn.jsdelivr.net/npm/text-encoding@0.7.0/lib/encoding.min.js"></script> 
+			<script src="{{ .WasmExecJSDir }}/wasm_exec.js"></script>
+			</head>
+			<body>
+			<div id="{{ .MountPoint }}">
+				<img style="position: absolute; top: 50%; left: 50%;" src="https://cdnjs.cloudflare.com/ajax/libs/galleriffic/2.0.1/css/loader.gif">
+			</div>
+			<script>
+			var wasmSupported = (typeof WebAssembly === "object");
+			if (wasmSupported) {
+				if (!WebAssembly.instantiateStreaming) { 
+					WebAssembly.instantiateStreaming = async (resp, importObject) => {
+						const source = await (await resp).arrayBuffer();
+						return await WebAssembly.instantiate(source, importObject);
+					};
+				}
+				const go = new Go();
+				WebAssembly.instantiateStreaming(fetch("{{ .WasmMainDir }}/{{ .WasmBinaryName }}"), go.importObject).then((result) => {
+					go.run(result.instance);
+				});
+			} else {
+				document.getElementById("{{ .MountPoint }}").innerHTML = 'This application requires WebAssembly support.  Please upgrade your browser.';
+			}
+			</script>
+	</body>
+</html>

--- a/cmd/vugu/initialise/templates/index.html.tmpl
+++ b/cmd/vugu/initialise/templates/index.html.tmpl
@@ -4,7 +4,7 @@
 			<title>{{ .PageTitle }}</title>
 			<meta charset="utf-8"/>
 			<script src="https://cdn.jsdelivr.net/npm/text-encoding@0.7.0/lib/encoding.min.js"></script> 
-			<script src="{{ .WasmExecJSDir }}/wasm_exec.js"></script>
+			<script src="{{ .WasmExecJSDir }}/wasm_exec.js"></script> <!-- wasm_exec.js must come from the $GOROOT/lib/wasm and must match the Go version used by the build -->
 			</head>
 			<body>
 			<div id="{{ .MountPoint }}">

--- a/cmd/vugu/initialise/templates/main_wasm.go.tmpl
+++ b/cmd/vugu/initialise/templates/main_wasm.go.tmpl
@@ -1,0 +1,46 @@
+//go:build wasm
+package main
+
+import (
+	"fmt"
+	{{if .RootStructPkgAlias }}{{ .RootStructPkgAlias }} {{end}}{{if .RootStructPkgImportPath }}"{{ .RootStructPkgImportPath }}"{{end}}
+	"github.com/vugu/vugu"
+	"github.com/vugu/vugu/domrender"
+)
+
+func main() {
+
+	mountPoint := "#" + {{ .MountPoint }}
+	fmt.Printf("Entering main(), -mount-point=%q\n", mountPoint)
+	defer fmt.PrintLn("Exiting main())
+
+	renderer, err := domrender.New(mountPoint)
+	if err != nil {
+		panic(err)
+	}
+	defer renderer.Release()
+
+	buildEnv, err := vugu.NewBuildEnv(renderer.EventEnv())
+	if err != nil {
+		panic(err)
+	}
+
+	if rootStructPkg != "" {
+		rootStructType := rootStructPkg + "." 
+	}
+
+	{{if .RootStructPkgAlias }}
+	rootBuilder := {{ .RootStructPkgAlias }}.{{ .RootStructType }}{}
+	{{else}}
+	rootBuilder := &{{ .RootStructType }}{}
+	{{end}}
+	for ok := true; ok; ok = renderer.EventWait() {
+
+		buildResults := buildEnv.RunBuild(rootBuilder)
+
+		err = renderer.Render(buildResults)
+		if err != nil {
+			panic(err)
+		}
+	}
+}

--- a/cmd/vugu/initialise/templates/main_wasm.go.tmpl
+++ b/cmd/vugu/initialise/templates/main_wasm.go.tmpl
@@ -30,7 +30,7 @@ func main() {
 	}
 
 	{{if .RootStructPkgAlias }}
-	rootBuilder := {{ .RootStructPkgAlias }}.{{ .RootStructType }}{}
+	rootBuilder := &{{ .RootStructPkgAlias }}.{{ .RootStructType }}{}
 	{{else}}
 	rootBuilder := &{{ .RootStructType }}{}
 	{{end}}

--- a/cmd/vugu/initialise/templates/root.go.tmpl
+++ b/cmd/vugu/initialise/templates/root.go.tmpl
@@ -1,0 +1,29 @@
+package main
+
+type {{ .RootStructType }} struct {
+	ShowWasm bool `vugu:"data"`
+	ShowGo   bool `vugu:"data"`
+	ShowVugu bool `vugu:"data"`
+}
+
+func (c *{{ .RootStructType }}) ShowWasmParagraph(event vugu.DOMEvent) {
+	event.PreventDefault()
+	c.ShowWasm=!c.ShowWasm
+}
+
+
+func (c *{{ .RootStructType }}) ShowGoParagraph(event vugu.DOMEvent) {
+	event.PreventDefault()
+	c.ShowGo=!c.ShowGo
+}
+
+
+func (c *{{ .RootStructType }}) ShowVuguParagraph(event vugu.DOMEvent) {
+	event.PreventDefault()
+	c.ShowVugu=!c.ShowVugu
+}
+
+func (c *{{ .RootStructType }}) Recent() bool {
+{
+	return time.Now().Year()>=2020
+}

--- a/cmd/vugu/initialise/templates/root.vugu
+++ b/cmd/vugu/initialise/templates/root.vugu
@@ -1,0 +1,39 @@
+<div>
+    <main role="main" class="container text-center">
+
+        <div class="mt-5">
+            <h1>Welcome to Vugu</h1>
+            <p class="lead">This page is being rendered via 
+                <a @click='c.ShowWasmParagraph(event)' href="https://webassembly.org/">WebAssembly</a>,
+                written in
+                <a @click='c.ShowGoParagraph(event)' href="https://golang.org/">Go</a>
+                using
+                <a @click='c.ShowVuguParagraph(event)' href="https://vugu.org/">Vugu</a>.
+            </p>
+
+            <div vg-if='c.ShowWasm' class="alert alert-primary" role="alert">
+                <strong>WebAssembly</strong> (abbreviated Wasm) is a binary instruction format.
+                It is designed as a portable target for compilation of high-level languages like Go/C/C++/Rust, 
+                enabling deployment on the web for client and server applications.
+                <a target="_blank" href="https://webassembly.org/">Read more at webassembly.org &raquo;</a>
+            </div>
+
+            <div vg-if='c.ShowGo' class="alert alert-primary" role="alert">
+                <strong>Go</strong> is an open source programming language that makes it easy to build simple, reliable, and efficient software.
+                <a target="_blank" href="https://golang.org/">Read more at golang.org &raquo;</a>
+            </div>
+
+            <div vg-if='c.ShowVugu' class="alert alert-primary" role="alert">
+                <strong>Vugu</strong> is a modern web UI library for Go+WebAssembly.
+                It is written in pure Go, works well in most modern browsers and supports 
+                <span vg-if='c.Recent()'>most</span> features one would expect from
+                a web framework.  It also makes a point of attempting to apply best practices 
+                from Go to web application UI development and prefers idiomatic solutions over
+                techniques that follow patterns from JavaScript wherever possible.
+                <a target="_blank" href="https://vugu.org/">Read more at vugu.org &raquo;</a>
+            </div>
+
+        </div>
+
+    </main>
+</div>

--- a/cmd/vugu/sh/cmd.go
+++ b/cmd/vugu/sh/cmd.go
@@ -1,0 +1,179 @@
+// Package sh provides helpers for running shell commands.
+package sh
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// RunCmd returns a function that will call Run with the given command. This is
+// useful for creating command aliases to make your scripts easier to read, like
+// this:
+//
+//	// in a helper file somewhere
+//	var g0 = sh.RunCmd("go")  // go is a keyword :(
+//
+//	// somewhere in your main code
+//		if err := g0("install", "github.com/gohugo/hugo"); err != nil {
+//			return err
+//	}
+//
+// Args passed to command get baked in as args to the command when you run it.
+// Any args passed in when you run the returned function will be appended to the
+// original args.  For example, this is equivalent to the above:
+//
+//	var goInstall = sh.RunCmd("go", "install") goInstall("github.com/gohugo/hugo")
+//
+// RunCmd uses Exec underneath, so see those docs for more details.
+func RunCmd(cmd string, args ...string) func(args ...string) error {
+	return func(args2 ...string) error {
+		return Run(cmd, append(args, args2...)...)
+	}
+}
+
+// OutCmd is like RunCmd except the command returns the output of the
+// command.
+func OutCmd(cmd string, args ...string) func(args ...string) (string, error) {
+	return func(args2 ...string) (string, error) {
+		return Output(cmd, append(args, args2...)...)
+	}
+}
+
+// Run is like RunWith, but doesn't specify any environment variables.
+func Run(cmd string, args ...string) error {
+	return RunWith(nil, cmd, args...)
+}
+
+// RunV is like Run, but always sends the command's stdout to os.Stdout.
+func RunV(cmd string, args ...string) error {
+	_, err := Exec(nil, os.Stdout, os.Stderr, cmd, args...)
+	return err
+}
+
+// RunWith runs the given command, directing stderr to this program's stderr.
+// Output to stdout is lost
+// It adds adds env to the
+// environment variables for the command being run. Environment variables should
+// be in the format name=value.
+func RunWith(env map[string]string, cmd string, args ...string) error {
+	var output io.Writer
+	_, err := Exec(env, output, os.Stderr, cmd, args...)
+	return err
+}
+
+// RunWithV is like RunWith, but always sends the command's stdout to os.Stdout.
+func RunWithV(env map[string]string, cmd string, args ...string) error {
+	_, err := Exec(env, os.Stdout, os.Stderr, cmd, args...)
+	return err
+}
+
+// Output runs the command and returns the text from stdout.
+func Output(cmd string, args ...string) (string, error) {
+	buf := &bytes.Buffer{}
+	_, err := Exec(nil, buf, os.Stderr, cmd, args...)
+	return strings.TrimSuffix(buf.String(), "\n"), err
+}
+
+// OutputWith is like RunWith, but returns what is written to stdout.
+func OutputWith(env map[string]string, cmd string, args ...string) (string, error) {
+	buf := &bytes.Buffer{}
+	_, err := Exec(env, buf, os.Stderr, cmd, args...)
+	return strings.TrimSuffix(buf.String(), "\n"), err
+}
+
+// Exec executes the command, piping its stdout and stderr to the given
+// writers. If the command fails, it will return an error that,
+// the command failed with. Env is a list of environment variables to set when
+// running the command, these override the current environment variables set
+// (which are also passed to the command). cmd and args may include references
+// to environment variables in $FOO format, in which case these will be
+// expanded before the command is run.
+//
+// Ran reports if the command ran (rather than was not found or not executable).
+// Code reports the exit code the command returned if it ran. If err == nil, ran
+// is always true and code is always 0.
+func Exec(env map[string]string, stdout, stderr io.Writer, cmd string, args ...string) (ran bool, err error) {
+	expand := func(s string) string {
+		s2, ok := env[s]
+		if ok {
+			return s2
+		}
+		return os.Getenv(s)
+	}
+	cmd = os.Expand(cmd, expand)
+	for i := range args {
+		args[i] = os.Expand(args[i], expand)
+	}
+	ran, code, err := doRun(env, stdout, stderr, cmd, args...)
+	if err == nil {
+		return true, nil
+	}
+	if ran {
+		return ran, fmt.Errorf(`running "%s %s" failed with exit code %d`, cmd, strings.Join(args, " "), code)
+	}
+	return ran, fmt.Errorf(`failed to run "%s %s: %w"`, cmd, strings.Join(args, " "), err)
+}
+
+func doRun(env map[string]string, stdout, stderr io.Writer, cmd string, args ...string) (ran bool, code int, err error) {
+	c := exec.CommandContext(context.Background(), cmd, args...)
+	c.Env = os.Environ()
+	for k, v := range env {
+		c.Env = append(c.Env, k+"="+v)
+	}
+	c.Stderr = stderr
+	c.Stdout = stdout
+	c.Stdin = os.Stdin
+
+	var quoted []string
+	for i := range args {
+		quoted = append(quoted, fmt.Sprintf("%q", args[i]))
+	}
+	err = c.Run()
+	return CmdRan(err), ExitStatus(err), err
+}
+
+// CmdRan examines the error to determine if it was generated as a result of a
+// command running via os/exec.Command.  If the error is nil, or the command ran
+// (even if it exited with a non-zero exit code), CmdRan reports true.  If the
+// error is an unrecognized type, or it is an error from exec.Command that says
+// the command failed to run (usually due to the command not existing or not
+// being executable), it reports false.
+func CmdRan(err error) bool {
+	if err == nil {
+		return true
+	}
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		return ee.Exited()
+	}
+	return false
+}
+
+type exitStatus interface {
+	ExitStatus() int
+}
+
+// ExitStatus returns the exit status of the error if it is an exec.ExitError
+// or if it implements ExitStatus() int.
+// 0 if it is nil or 1 if it is a different error.
+func ExitStatus(err error) int {
+	if err == nil {
+		return 0
+	}
+	if e, ok := err.(exitStatus); ok {
+		return e.ExitStatus()
+	}
+	var e *exec.ExitError
+	if errors.As(err, &e) {
+		if ex, ok := e.Sys().(exitStatus); ok {
+			return ex.ExitStatus()
+		}
+	}
+	return 1
+}

--- a/cmd/vugu/sh/cmd_test.go
+++ b/cmd/vugu/sh/cmd_test.go
@@ -27,10 +27,9 @@ func TestExitCode(t *testing.T) {
 	if !ran {
 		t.Error("ran returned as false, but should have been true")
 	}
-	code := ExitStatus(err)
-	if code != 99 {
-		t.Fatalf("expected exit status 99, but got %v", code)
-	}
+	// the updated (copied) code in github.com/vugu/vugu/cmd/vugu/sh no longer uses github.com/magefiles/mage/mg.FatalF
+	// and so does not use the mg/FatalF type.
+	// As a result we can no longer test the exit code in these tests.
 }
 
 func TestEnv(t *testing.T) {
@@ -96,13 +95,10 @@ func TestExitStatusNonExecError(t *testing.T) {
 	}
 }
 
-func TestExitStatusFromExec(t *testing.T) {
-	_, err := Exec(nil, nil, nil, os.Args[0], "-helper", "-exit", "42")
-	code := ExitStatus(err)
-	if code != 42 {
-		t.Fatalf("expected exit status 42, got %d", code)
-	}
-}
+// the updated (copied) code in github.com/vugu/vugu/cmd/vugu/sh no longer uses github.com/magefiles/mage/mg.FatalF
+// and so does not use the mg/FatalF type.
+// As a result we can no longer test the exit code in these tests.
+// As a result the test TestExitStatusFromExec has been removed
 
 func TestRunCmd(t *testing.T) {
 	echoHello := RunCmd("echo", "hello")

--- a/cmd/vugu/sh/cmd_test.go
+++ b/cmd/vugu/sh/cmd_test.go
@@ -1,0 +1,124 @@
+package sh
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"testing"
+)
+
+func TestOutCmd(t *testing.T) {
+	cmd := OutCmd(os.Args[0], "-printArgs", "foo", "bar")
+	out, err := cmd("baz", "bat")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := "[foo bar baz bat]"
+	if out != expected {
+		t.Fatalf("expected %q but got %q", expected, out)
+	}
+}
+
+func TestExitCode(t *testing.T) {
+	ran, err := Exec(nil, nil, nil, os.Args[0], "-helper", "-exit", "99")
+	if err == nil {
+		t.Fatal("unexpected nil error from run")
+	}
+	if !ran {
+		t.Error("ran returned as false, but should have been true")
+	}
+	code := ExitStatus(err)
+	if code != 99 {
+		t.Fatalf("expected exit status 99, but got %v", code)
+	}
+}
+
+func TestEnv(t *testing.T) {
+	env := "SOME_REALLY_LONG_MAGEFILE_SPECIFIC_THING"
+	out := &bytes.Buffer{}
+	ran, err := Exec(map[string]string{env: "foobar"}, out, nil, os.Args[0], "-printVar", env)
+	if err != nil {
+		t.Fatalf("unexpected error from runner: %#v", err)
+	}
+	if !ran {
+		t.Error("expected ran to be true but was false.")
+	}
+	if out.String() != "foobar\n" {
+		t.Errorf("expected foobar, got %q", out)
+	}
+}
+
+func TestNotRun(t *testing.T) {
+	ran, err := Exec(nil, nil, nil, "thiswontwork")
+	if err == nil {
+		t.Fatal("unexpected nil error")
+	}
+	if ran {
+		t.Fatal("expected ran to be false but was true")
+	}
+}
+
+func TestAutoExpand(t *testing.T) {
+	t.Setenv("MAGE_FOOBAR", "baz")
+	s, err := Output("echo", "$MAGE_FOOBAR")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s != "baz" {
+		t.Fatalf(`Expected "baz" but got %q`, s)
+	}
+}
+
+func TestCmdRanNilErr(t *testing.T) {
+	if !CmdRan(nil) {
+		t.Fatal("CmdRan(nil) should return true")
+	}
+}
+
+func TestCmdRanNotFound(t *testing.T) {
+	_, err := Exec(nil, nil, nil, "thiswontwork")
+	if CmdRan(err) {
+		t.Fatal("CmdRan should return false for not-found command")
+	}
+}
+
+func TestExitStatusNil(t *testing.T) {
+	code := ExitStatus(nil)
+	if code != 0 {
+		t.Fatalf("expected 0 for nil error, got %d", code)
+	}
+}
+
+func TestExitStatusNonExecError(t *testing.T) {
+	code := ExitStatus(errors.New("generic error"))
+	if code != 1 {
+		t.Fatalf("expected 1 for generic error, got %d", code)
+	}
+}
+
+func TestExitStatusFromExec(t *testing.T) {
+	_, err := Exec(nil, nil, nil, os.Args[0], "-helper", "-exit", "42")
+	code := ExitStatus(err)
+	if code != 42 {
+		t.Fatalf("expected exit status 42, got %d", code)
+	}
+}
+
+func TestRunCmd(t *testing.T) {
+	echoHello := RunCmd("echo", "hello")
+	err := echoHello("world")
+	// RunWith directs output based on verbose, so just check no error
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestOutputWith(t *testing.T) {
+	out, err := OutputWith(map[string]string{"MY_TEST_VAR": "xyz"}, os.Args[0], "-printVar", "MY_TEST_VAR")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "xyz" {
+		t.Fatalf("expected 'xyz', got %q", out)
+	}
+}

--- a/cmd/vugu/sh/helpers.go
+++ b/cmd/vugu/sh/helpers.go
@@ -1,0 +1,43 @@
+package sh
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// Rm removes the given file or directory even if non-empty. It will not return
+// an error if the target doesn't exist, only if the target cannot be removed.
+func Rm(path string) error {
+	err := os.RemoveAll(path)
+	if err == nil || os.IsNotExist(err) {
+		return nil
+	}
+	return fmt.Errorf(`failed to remove %s: %w`, path, err)
+}
+
+// Copy robustly copies the source file to the destination, overwriting the destination if necessary.
+func Copy(dst, src string) error {
+	from, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf(`can't copy %s: %w`, src, err)
+	}
+	defer from.Close()
+	finfo, err := from.Stat()
+	if err != nil {
+		return fmt.Errorf(`can't stat %s: %w`, src, err)
+	}
+	to, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, finfo.Mode())
+	if err != nil {
+		return fmt.Errorf(`can't copy to %s: %w`, dst, err)
+	}
+	_, err = io.Copy(to, from)
+	if err != nil {
+		_ = to.Close()
+		return fmt.Errorf(`error copying %s to %s: %w`, src, dst, err)
+	}
+	if err := to.Close(); err != nil {
+		return fmt.Errorf(`error closing %s: %w`, dst, err)
+	}
+	return nil
+}

--- a/cmd/vugu/sh/helpers_test.go
+++ b/cmd/vugu/sh/helpers_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/magefile/mage/sh"
+	"github.com/vugu/vugu/cmd/vugu/sh"
 )
 
 // compareFiles checks that two files are identical for testing purposes. That means they have the same length,

--- a/cmd/vugu/sh/helpers_test.go
+++ b/cmd/vugu/sh/helpers_test.go
@@ -1,0 +1,177 @@
+package sh_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/magefile/mage/sh"
+)
+
+// compareFiles checks that two files are identical for testing purposes. That means they have the same length,
+// the same contents, and the same permissions. It does NOT mean they have the same timestamp, as that is expected
+// to change in normal Mage sh.Copy operation.
+func compareFiles(file1, file2 string) error {
+	s1, err := os.Stat(file1)
+	if err != nil {
+		return fmt.Errorf("can't stat %s: %w", file1, err)
+	}
+	s2, err := os.Stat(file2)
+	if err != nil {
+		return fmt.Errorf("can't stat %s: %w", file2, err)
+	}
+	if s1.Size() != s2.Size() {
+		return fmt.Errorf("files %s and %s have different sizes: %d vs %d", file1, file2, s1.Size(), s2.Size())
+	}
+	if s1.Mode() != s2.Mode() {
+		return fmt.Errorf("files %s and %s have different permissions: %#4o vs %#4o", file1, file2, s1.Mode(), s2.Mode())
+	}
+	f1bytes, err := os.ReadFile(file1)
+	if err != nil {
+		return fmt.Errorf("can't read %s: %w", file1, err)
+	}
+	f2bytes, err := os.ReadFile(file2)
+	if err != nil {
+		return fmt.Errorf("can't read %s: %w", file2, err)
+	}
+	if !bytes.Equal(f1bytes, f2bytes) {
+		return fmt.Errorf("files %s and %s have different contents", file1, file2)
+	}
+	return nil
+}
+
+func TestHelpers(t *testing.T) {
+	mytmpdir := t.TempDir()
+	defer func() {
+		derr := os.RemoveAll(mytmpdir)
+		if derr != nil {
+			fmt.Printf("error cleaning up after TestHelpers: %v", derr)
+		}
+	}()
+	srcname := filepath.Join(mytmpdir, "test1.txt")
+	err := os.WriteFile(srcname, []byte("All work and no play makes Jack a dull boy."), 0o600)
+	if err != nil {
+		t.Fatalf("can't create test file %s: %v", srcname, err)
+	}
+	destname := filepath.Join(mytmpdir, "test2.txt")
+
+	t.Run("sh/copy", func(t *testing.T) {
+		cerr := sh.Copy(destname, srcname)
+		if cerr != nil {
+			t.Errorf("test file copy from %s to %s failed: %v", srcname, destname, cerr)
+		}
+		cerr = compareFiles(srcname, destname)
+		if cerr != nil {
+			t.Errorf("test file copy verification failed: %v", cerr)
+		}
+	})
+
+	// While we've got a temporary directory, test how forgiving sh.Rm is
+	t.Run("sh/rm/ne", func(t *testing.T) {
+		nef := filepath.Join(mytmpdir, "file_not_exist.txt")
+		rerr := sh.Rm(nef)
+		if rerr != nil {
+			t.Errorf("sh.Rm complained when removing nonexistent file %s: %v", nef, rerr)
+		}
+	})
+
+	t.Run("sh/copy/ne", func(t *testing.T) {
+		nef := filepath.Join(mytmpdir, "file_not_exist.txt")
+		nedf := filepath.Join(mytmpdir, "file_not_exist2.txt")
+		cerr := sh.Copy(nedf, nef)
+		if cerr == nil {
+			t.Errorf("sh.Copy succeeded copying nonexistent file %s", nef)
+		}
+	})
+
+	// We test sh.Rm by clearing up our own test files and directories
+	t.Run("sh/rm", func(t *testing.T) {
+		rerr := sh.Rm(destname)
+		if rerr != nil {
+			t.Errorf("failed to remove file %s: %v", destname, rerr)
+		}
+		rerr = sh.Rm(srcname)
+		if rerr != nil {
+			t.Errorf("failed to remove file %s: %v", srcname, rerr)
+		}
+		rerr = sh.Rm(mytmpdir)
+		if rerr != nil {
+			t.Errorf("failed to remove dir %s: %v", mytmpdir, rerr)
+		}
+		_, rerr = os.Stat(mytmpdir)
+		if rerr == nil {
+			t.Errorf("removed dir %s but it's still there?", mytmpdir)
+		}
+	})
+
+	t.Run("sh/rm/nedir", func(t *testing.T) {
+		rerr := sh.Rm(mytmpdir)
+		if rerr != nil {
+			t.Errorf("sh.Rm complained removing nonexistent dir %s", mytmpdir)
+		}
+	})
+}
+
+func TestCopyNonExistentSource(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "dst.txt")
+	err := sh.Copy(dst, filepath.Join(dir, "nonexistent.txt"))
+	if err == nil {
+		t.Fatal("expected error copying from non-existent source")
+	}
+}
+
+func TestCopyReadOnlyDir(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	if err := os.WriteFile(src, []byte("data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Try to copy to a path inside a non-existent subdirectory
+	dst := filepath.Join(dir, "nodir", "dst.txt")
+	err := sh.Copy(dst, src)
+	if err == nil {
+		t.Fatal("expected error copying to non-existent directory")
+	}
+}
+
+func TestCopyPreservesPermissions(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	if err := os.WriteFile(src, []byte("data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(dir, "dst.txt")
+	if err := sh.Copy(dst, src); err != nil {
+		t.Fatal(err)
+	}
+	srcInfo, _ := os.Stat(src)
+	dstInfo, _ := os.Stat(dst)
+	if srcInfo.Mode() != dstInfo.Mode() {
+		t.Errorf("permissions differ: src=%v dst=%v", srcInfo.Mode(), dstInfo.Mode())
+	}
+}
+
+func TestCopyOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	dst := filepath.Join(dir, "dst.txt")
+	if err := os.WriteFile(src, []byte("new content"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, []byte("old content"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := sh.Copy(dst, src); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "new content" {
+		t.Fatalf("expected 'new content', got %q", string(data))
+	}
+}

--- a/cmd/vugu/sh/testmain_test.go
+++ b/cmd/vugu/sh/testmain_test.go
@@ -1,0 +1,46 @@
+package sh
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+)
+
+var (
+	helperCmd bool
+	printArgs bool
+	stderr    string
+	stdout    string
+	exitCode  int
+	printVar  string
+)
+
+func init() { //nolint:gochecknoinits // required for test flag setup
+	flag.BoolVar(&helperCmd, "helper", false, "")
+	flag.BoolVar(&printArgs, "printArgs", false, "")
+	flag.StringVar(&stderr, "stderr", "", "")
+	flag.StringVar(&stdout, "stdout", "", "")
+	flag.IntVar(&exitCode, "exit", 0, "")
+	flag.StringVar(&printVar, "printVar", "", "")
+}
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+
+	if printArgs {
+		fmt.Println(flag.Args())
+		return
+	}
+	if printVar != "" {
+		fmt.Println(os.Getenv(printVar))
+		return
+	}
+
+	if helperCmd {
+		_, _ = fmt.Fprintln(os.Stderr, stderr)
+		_, _ = fmt.Fprintln(os.Stdout, stdout)
+		os.Exit(exitCode)
+	}
+	os.Exit(m.Run())
+}

--- a/cmd/vugu/vugu.go
+++ b/cmd/vugu/vugu.go
@@ -16,7 +16,7 @@ import (
 // The root `vugu` command entry point.
 func main() {
 	// Calculate the version string.
-	// We want this as a separate string variable becase we need to assign it to the
+	// We want this as a separate string variable because we need to assign it to the
 	// cli.Command.Version field. Any errors need to be handled here.
 	v, err := version.VersionString()
 	if err != nil {
@@ -37,7 +37,9 @@ func main() {
 		version.Version(context.Background(), cmd)
 	}
 	cmd := &cli.Command{
-		Version: v, // the version is printed under the VERSION: section if `vugu` is called without arguments.
+		Version:   v, // the version is printed under the VERSION: section if `vugu` is called without arguments.
+		Usage:     "bootstraps and builds a vugu project",
+		ArgsUsage: "[GO_MODULE_NAME]",
 		Commands: []*cli.Command{
 			// The version sub command. See the version.Version
 			// Also called in response to the "-v" and "--version" flags.
@@ -48,9 +50,10 @@ func main() {
 				Action:  version.Version,
 			},
 			{
-				Name:    "gen",
-				Aliases: []string{"g"},
-				Usage:   "Generate code",
+				Name:      "gen",
+				Aliases:   []string{"g"},
+				Usage:     "Generate the Go code from the .vugu files in the directory",
+				ArgsUsage: "[OPTIONS] DIRECTORY",
 				Flags: []cli.Flag{
 					&cli.BoolFlag{
 						Name:        "skip-go-mod",
@@ -61,7 +64,7 @@ func main() {
 					&cli.BoolFlag{
 						Name:        "skip-main",
 						Value:       false,
-						Usage:       "Donot try to create main.go as needed",
+						Usage:       "Do not try to create main.go as needed",
 						Destination: &gen.Opts.SkipMainGo,
 					},
 					&cli.BoolFlag{
@@ -86,9 +89,11 @@ func main() {
 				Action: gen.Gen,
 			},
 			{
-				Name:    "init",
-				Aliases: []string{"i"},
-				Usage:   "Bootstrap a new vugu project",
+				Name:      "init",
+				Aliases:   []string{"i"},
+				Usage:     "Bootstrap a new vugu project",
+				ArgsUsage: "[OPTIONS] GO_MODULE_NAME",
+				//ArgsUsage: "GO_MODULE_NAME",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
 						Name:        "dir",

--- a/cmd/vugu/vugu.go
+++ b/cmd/vugu/vugu.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/urfave/cli/v3"
 	"github.com/vugu/vugu/cmd/vugu/gen"
+	"github.com/vugu/vugu/cmd/vugu/initialise"
 	"github.com/vugu/vugu/cmd/vugu/version"
 )
 
@@ -84,6 +85,88 @@ func main() {
 				},
 				Action: gen.Gen,
 			},
+			{
+				Name:    "init",
+				Aliases: []string{"i"},
+				Usage:   "Bootstrap a new vugu project",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:        "dir",
+						Value:       ".",
+						Usage:       "Creates a project in the specified directory rather than the current one",
+						Destination: &initialise.Opts.Dir,
+					},
+					&cli.StringFlag{
+						Name:        "pagetitle",
+						Value:       "Vugu Index Page",
+						Usage:       "The page title of the generated index.html file",
+						Destination: &initialise.Opts.PageTitle,
+					},
+					&cli.StringFlag{
+						Name:        "wasmexecjsdir",
+						Value:       "",
+						Usage:       "The directory path on the web server (relative to the web document root) of the wasm_exec.js file. Any training slash will be removed. Relative paths are allowed. (default: an empty string)",
+						Destination: &initialise.Opts.WasmExecJSDir,
+					},
+					&cli.StringFlag{
+						Name:        "mountpoint",
+						Value:       "vugu-mount-point",
+						Usage:       "The id of the top level <div> that contains the wasm binary. Must be a valid HTML identifier", // the id can take any form according to the HTML spec https://html.spec.whatwg.org/multipage/dom.html#the-id-attribute so vugu does not check this.
+						Destination: &initialise.Opts.MountPoint,
+					},
+					&cli.StringFlag{
+						Name:        "wasmmaindir",
+						Value:       "",
+						Usage:       "The directory path on the web server (relative to the web document root) of the wasm binary file. Any training slash will be removed. Relative paths are allowed. (default: an empty string)",
+						Destination: &initialise.Opts.WasmMainDir,
+					},
+					&cli.StringFlag{
+						Name:        "wasmbinaryname",
+						Value:       "main.wasm",
+						Usage:       "The name of the wasm binary file.",
+						Destination: &initialise.Opts.WasmBinaryName,
+					},
+					&cli.StringFlag{
+						Name:        "wasmgofilename",
+						Value:       "main_wasm.go",
+						Usage:       "The name of the Go source code file that contains the main function.",
+						Destination: &initialise.Opts.WasmGoFilename,
+					},
+
+					&cli.StringFlag{
+						Name:        "rootstructpkgimportpath",
+						Value:       "",
+						Usage:       "The import path of the package that contains the root struct. If empty this is assumed to be the main package. (default: an empty string)",
+						Destination: &initialise.Opts.RootStructPkgImportPath,
+					},
+					&cli.StringFlag{
+						Name:        "rootstructpkgalias",
+						Value:       "",
+						Usage:       "The alias for the package that contains the root struct. If empty then the package name from the import path is used. . (default: an empty string)",
+						Destination: &initialise.Opts.RootStructPkgAlias,
+					},
+					&cli.StringFlag{
+						Name:        "rootstructtype",
+						Value:       "Root",
+						Usage:       "The type name of the root struct. The type must exist in the --rootstructpkg if supplied. Otherwise it must exist in the main package.",
+						Destination: &initialise.Opts.RootStructType,
+					},
+					&cli.BoolFlag{
+						Name:        "noindex",
+						Value:       false,
+						Usage:       "Do not generate an index.html file at the root of the module directory.",
+						Destination: &initialise.Opts.NoIndex,
+					},
+					&cli.BoolFlag{
+						Name:        "nomain",
+						Value:       false,
+						Usage:       "Do not generate an main_wasm.go file at the root of the module directory.",
+						Destination: &initialise.Opts.NoMain,
+					},
+				},
+				Action: initialise.Initialise, // don't use Init or init so as not to confuse with the package initialisation function "init()"
+			},
+
 			// Add other command here e.g. init, possibly with their own sub commands as shown in the comments
 			// 	{
 			// 		Name:    "init",


### PR DESCRIPTION
Add support for a 'vugu init` command to produce a boot strapped project from a set of (internal) templates.

The bootstrapped project is a copy of the 'https://github.com/vugu-examples/simple' example.

The currently supported options are:

```
$vugu help init
NAME:
   vugu init - Bootstrap a new vugu project

USAGE:
   vugu init [OPTIONS] GO_MODULE_NAME

OPTIONS:
   --dir string                      Creates a project in the specified directory rather than the current one (default: ".")
   --pagetitle string                The page title of the generated index.html file (default: "Vugu Index Page")
   --wasmexecjsdir string            The directory path on the web server (relative to the web document root) of the wasm_exec.js file. Any training slash will be removed. Relative paths are allowed. (default: an empty string)
   --mountpoint string               The id of the top level <div> that contains the wasm binary. Must be a valid HTML identifier (default: "vugu-mount-point")
   --wasmmaindir string              The directory path on the web server (relative to the web document root) of the wasm binary file. Any training slash will be removed. Relative paths are allowed. (default: an empty string)
   --wasmbinaryname string           The name of the wasm binary file. (default: "main.wasm")
   --wasmgofilename string           The name of the Go source code file that contains the main function. (default: "main_wasm.go")
   --rootstructpkgimportpath string  The import path of the package that contains the root struct. If empty this is assumed to be the main package. (default: an empty string)
   --rootstructpkgalias string       The alias for the package that contains the root struct. If empty then the package name from the import path is used. . (default: an empty string)
   --rootstructtype string           The type name of the root struct. The type must exist in the --rootstructpkg if supplied. Otherwise it must exist in the main package. (default: "Root")
   --noindex                         Do not generate an index.html file at the root of the module directory. (default: false)
   --nomain                          Do not generate an main_wasm.go file at the root of the module directory. (default: false)
   --help, -h                        show help

```

See Issue #340.