### PR TITLE
Fix the magefile to ensure that the `vgfrom` package is always built

### DIFF
--- a/magefiles/helpers.go
+++ b/magefiles/helpers.go
@@ -93,6 +93,14 @@ func deleteGeneratedFiles(path string, d fs.DirEntry, err error) error {
 }
 
 func generatedFilesCheck(dir string) error {
+	if err := buildVgForm(dir); err != nil {
+		return err
+	}
+	// now check the generated files are identical
+	return gitDiffFiles()
+}
+
+func buildVgForm(dir string) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return err
@@ -109,11 +117,6 @@ func generatedFilesCheck(dir string) error {
 	if err != nil {
 		return err
 	}
-	// now run go mod tidy
-	err = runGoModTidyInCurrentDir()
-	if err != nil {
-		return err
-	}
-	// now check the generated files are identical
-	return gitDiffFiles()
+	// now run go mod tidy - is this strictly necessary? (vgfrom is a package)
+	return runGoModTidyInCurrentDir()
 }

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -128,7 +128,11 @@ func Build() error {
 	}
 	// install the vugufmt command by executing
 	err = goInstall("github.com/vugu/vugu/cmd/vugufmt@latest") // vugufmt can use the goimports tool
-	return err
+	if err != nil {
+		return err
+	}
+	// ensure we always build the vgform package - it contains generated code that may nee dto be rebuild
+	return buildVgForm("./vgform")
 }
 
 // Like Build but additionally confirm that the generated files in the `vgform` package that should have been committed are correct.

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -479,11 +479,11 @@ func singleExample(moduleName string, withGeneratedFilesCheck bool) error {
 // Builds, and serves a single wasm test using a local nginx container.
 // The usage is:
 //
-//	mage SingleWasmtest <wasm-test-module-name>
+//	mage SingleWasmTest <wasm-test-module-name>
 //
 // e.g.
 //
-//	mage SingleExample gtihub.com/vugu/vugu/wasm-test-suite/test-002-click
+//	mage SingleWasmTest gtihub.com/vugu/vugu/wasm-test-suite/test-002-click
 //
 // The examples will be served at
 //
@@ -505,7 +505,7 @@ func SingleWasmTestWithGeneratedFilesCheck(moduleName string) error {
 
 func singleWasmTest(moduleName string, withGeneratedFilesCheck bool) error {
 	mg.SerialDeps(Build, PullLatestNginxImage)
-	StartLocalNginxForExamples()
+	StartLocalNginxForWasmTestSuite()
 	return buildSingleModule(WasmTestSuiteDir, moduleName, withGeneratedFilesCheck)
 }
 


### PR DESCRIPTION
Fix: Ensure we always build `vgform` when building locally. Previously `vgfrom` which containes `vugu` generated code was only built by the `allGitHubAction` built target (which the Github Action runs). This change ensures it is also built bu the local `Build` target. The Github Action builds are not impacted by this change.

Fix: Ensure we correctly name the nginx container that is used to run a single wasm example.

