### PR TITLE
v2 Stop 'vugu gen' from creating a 'main_wasm.go' file

### DIFF
--- a/v2/README.md
+++ b/v2/README.md
@@ -23,6 +23,8 @@ The list of changes are:
 - [x] Delete the `vugufmt` package and the `vugufmt` command.
 - [x] Delete the `vgfrom` package and wasm test `test-020-vgform`
 - [x] Delete the `vuggen` command. Use `vugu gen` instead.
+- [x] Stop the `vugu gen` creating a `main_wasm.go`. This is a behaviour breaking change. Use `vugu init` to create the initial `main_wasm.go`.
+
 
 The original v0.y.z Readme follows.
 

--- a/v2/cmd/vugu/vugu.go
+++ b/v2/cmd/vugu/vugu.go
@@ -62,12 +62,6 @@ func main() {
 						Destination: &gen.Opts.SkipGoMod,
 					},
 					&cli.BoolFlag{
-						Name:        "skip-main",
-						Value:       false,
-						Usage:       "Do not try to create main.go as needed",
-						Destination: &gen.Opts.SkipMainGo,
-					},
-					&cli.BoolFlag{
 						Name:        "tinygo",
 						Value:       false,
 						Usage:       "Generate code intended for compilation under Tinygo",

--- a/v2/gen/parser-go-pkg.go
+++ b/v2/gen/parser-go-pkg.go
@@ -12,7 +12,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"text/template"
 	"time"
 
 	"github.com/vugu/xxhash"
@@ -216,112 +215,9 @@ func (p *ParserGoPkg) Run() error {
 
 	// after the code generation is done, check the package for the various names in question to see
 	// what we need to generate
-	namesFound, err := goPkgCheckNames(p.pkgPath, namesToCheck)
+	_, err = goPkgCheckNames(p.pkgPath, namesToCheck)
 	if err != nil {
 		return err
-	}
-
-	// if main package, generate main_wasm.go with default stuff if no main func in the package and no main_wasm.go
-	if (!p.opts.SkipMainGo) && pkgName == "main" {
-
-		mainGoPath := filepath.Join(p.pkgPath, "main_wasm.go")
-		// log.Printf("namesFound: %#v", namesFound)
-		// log.Printf("maingo found: %v", fileExists(mainGoPath))
-		// if _, ok := namesFound["main"]; (!ok) && !fileExists(mainGoPath) {
-
-		// NOTE: For now we're disabling the "main" symbol name check, because in single-dir cases
-		// it's picking up the main_wasm.go in server.go (even though it's excluded via build tag).  This
-		// needs some more thought but for now this will work for the common cases.
-		if !fileExists(mainGoPath) {
-
-			// log.Printf("WRITING TO main_wasm.go STUFF")
-			var buf bytes.Buffer
-			t, err := template.New("_main_").Parse(`// +build wasm
-{{$opts := .Parser.Opts}}
-package main
-
-import (
-	"fmt"
-{{if not $opts.TinyGo}}
-	"flag"
-{{end}}
-
-	"github.com/vugu/vugu/v2"
-	"github.com/vugu/vugu/v2/domrender"
-)
-
-func main() {
-
-{{if $opts.TinyGo}}
-	var mountPoint *string
-	{
-		mp := "#vugu_mount_point"
-		mountPoint = &mp
-	}
-{{else}}
-	mountPoint := flag.String("mount-point", "#vugu_mount_point", "The query selector for the mount point for the root component, if it is not a full HTML component")
-	flag.Parse()
-{{end}}
-
-	fmt.Printf("Entering main(), -mount-point=%q\n", *mountPoint)
-	{{if not $opts.TinyGo}}defer fmt.Printf("Exiting main()\n")
-{{end}}
-
-	renderer, err := domrender.New(*mountPoint)
-	if err != nil {
-		panic(err)
-	}
-	{{if not $opts.TinyGo}}defer renderer.Release()
-{{end}}
-
-	buildEnv, err := vugu.NewBuildEnv(renderer.EventEnv())
-	if err != nil {
-		panic(err)
-	}
-
-{{if (index .NamesFound "vuguSetup")}}
-	rootBuilder := vuguSetup(buildEnv, renderer.EventEnv())
-{{else}}
-	rootBuilder := &Root{}
-{{end}}
-
-
-	for ok := true; ok; ok = renderer.EventWait() {
-
-		buildResults := buildEnv.RunBuild(rootBuilder)
-		
-		err = renderer.Render(buildResults)
-		if err != nil {
-			panic(err)
-		}
-	}
-	
-}
-`)
-			if err != nil {
-				return err
-			}
-			err = t.Execute(&buf, map[string]any{
-				"Parser":     p,
-				"NamesFound": namesFound,
-			})
-			if err != nil {
-				return err
-			}
-
-			bufstr := buf.String()
-			bufstr, err = gofmt(bufstr)
-			if err != nil {
-				log.Printf("WARNING: gofmt on main_wasm.go failed: %v", err)
-			}
-
-			err = os.WriteFile(mainGoPath, []byte(bufstr), 0644)
-			if err != nil {
-				return err
-			}
-
-		}
-
 	}
 
 	// write go.mod if it doesn't exist and not disabled - actually this really only makes sense for main,

--- a/v2/gen/parser-go-pkg_test.go
+++ b/v2/gen/parser-go-pkg_test.go
@@ -96,6 +96,7 @@ func TestRun(t *testing.T) {
 			infiles: map[string]string{
 				"root.vugu": `<div>root here</div>`,
 				"go.mod":    "module testcase\nreplace github.com/vugu/vugu/v2 => " + pwd + "\n",
+				"main.go":   "package main\nfunc main(){}",
 			},
 			out: map[string][]string{
 				"root_gen.go":      {`func \(c \*Root\) Build`},


### PR DESCRIPTION
This fix should have been applied when the `vugu init` command was created.

The problem is that the gen/ParserGoPkg.Run() method will create a 'main_wasm.go' file unless the '--skip-main' option was specified on the command line.

The default setting for '--skip-main' is false i.e. do create a 'main_wasm.go'.

But this is unnecessary. The project has for a long time provided a 'main_wasm.go' file for all of the wasm-tests and the examples.

The newer 'vugu init' tool will create one for new projects if the developer does not want to create one for their project.

But, during all of this each time 'vugu gen' was run, a new 'main_wasm.go' was created.

The only reason this hasn't been picked up is that the default 'main_wasm.go' for a standard Go build, was identical to the existing 'main_wasm.go' already in the test/project.

This change removes the creation of the `main_wasm.go` from the gen/ParserGoPkg.Run() method.
The 'main_wasm.go' must now be created before 'vugu gen' is run.