### PR TITLE
v2 - remove tinygo references from the magefiles.

### DIFF
--- a/v2/magefiles/consts.go
+++ b/v2/magefiles/consts.go
@@ -6,7 +6,6 @@ const DockerCmdExeName = "docker"
 const GitCmdExeName = "git"
 
 const GoLangCiLintImageName = "golangci/golangci-lint:latest-alpine"
-const TinyGoImageName = "tinygo/tinygo:latest"
 const NginxImageName = "nginx:latest"
 const ChromeDpHeadlessShellImageName = "chromedp/headless-shell:latest"
 

--- a/v2/magefiles/gocmd.go
+++ b/v2/magefiles/gocmd.go
@@ -48,10 +48,7 @@ func goInstallWithSetVariable(variable, value, pkgName string) error {
 }
 
 // Get the GOROOT for the standard go compiler via go env
-// we need a tinygo version of this!
 func goGetGoRoot() (string, error) {
-	// TODO - ref Issue #344 - https://github.com/vugu/vugu/v2/issues/344
-	// What does tinygo do???? The GOROOT has to point to a different location so we need to take this into account.
 	return goCmdCaptureOutput("env", GoRoot)
 }
 

--- a/v2/magefiles/magefile.go
+++ b/v2/magefiles/magefile.go
@@ -328,14 +328,6 @@ func StopLocalNginxForExamples() error {
 	return nil
 }
 
-// Pulls the latest version of the 'tinygo' Go compiler docker image. 'tinygo' is an alternative Go compiler used by the 'vugu' to generate the Web Assembly (wasm) files.
-// 'vugu' uses it only to ensure tha the 'wasm-test-suite' can be built using 'tinygo' compiler.
-// 'tinygo' DOES NOT support the full Go standard library, when compiling to wasm. As such you may not be able to compile your project using 'tinygo'. See: https://tinygo.org/docs/reference/lang-support/stdlib/
-func PullLatestTinyGoDockerImage() error {
-	mg.Deps(CheckRequiredCmdsExist)
-	return dockerPullImage(TinyGoImageName)
-}
-
 // Builds and serves all of the examples via a local nginx container.
 // The examples will be served at
 //


### PR DESCRIPTION
Remove any reference to tinygo from the magefiles. Building vugu with tinygo is not currently supported by the v2 version.