### PR TITLE
v2 - remove support for generating tinygo compatible files.

### DIFF
--- a/v2/cmd/vugu/vugu.go
+++ b/v2/cmd/vugu/vugu.go
@@ -62,12 +62,6 @@ func main() {
 						Destination: &gen.Opts.SkipGoMod,
 					},
 					&cli.BoolFlag{
-						Name:        "tinygo",
-						Value:       false,
-						Usage:       "Generate code intended for compilation under Tinygo",
-						Destination: &gen.Opts.TinyGo,
-					},
-					&cli.BoolFlag{
 						Name:        "s",
 						Value:       false,
 						Usage:       "Merge generated code for a package into a single file",

--- a/v2/gen/parser-go-pkg.go
+++ b/v2/gen/parser-go-pkg.go
@@ -30,7 +30,6 @@ type ParserGoPkg struct {
 type ParserGoPkgOpts struct {
 	SkipGoMod        bool    // do not try and create go.mod if it doesn't exist
 	SkipMainGo       bool    // do not try and create main_wasm.go if it doesn't exist in a main package
-	TinyGo           bool    // emit code intended for TinyGo compilation
 	GoFileNameAppend *string // suffix to append to file names, after base name plus .go, if nil then "_gen" is used
 	MergeSingle      bool    // merge all output files into a single one
 	MergeSingleName  string  // name of merged output file, only used if MergeSingle is true, defaults to "0_components_gen.go"
@@ -191,7 +190,6 @@ func (p *ParserGoPkg) Run() error {
 		// pg.DataType = pg.ComponentType + "Data"
 		pg.OutDir = p.pkgPath
 		pg.OutFile = goFileName
-		pg.TinyGo = p.opts.TinyGo
 
 		// add to our list of names to check after
 		namesToCheck = append(namesToCheck, pg.StructType)

--- a/v2/gen/parser-go.go
+++ b/v2/gen/parser-go.go
@@ -27,7 +27,6 @@ type ParserGo struct {
 	OutFile string // output file name with ".go" suffix
 
 	NoOptimizeStatic bool // set to true to disable optimization of static blocks of HTML into vg-html expressions
-	TinyGo           bool // set to true to enable TinyGo compatability changes to the generated code
 }
 
 func gofmt(pgm string) (string, error) {


### PR DESCRIPTION
Removed the "--tinygo" option from the vugu gen command. This stops generating Go source files that are compatible with tinygo.

Tinygo is not currently suported by the v2 module.