### PR TITLE
v2 - remove unused tinygo build tags

### DIFF
--- a/v2/comp-key-default.go
+++ b/v2/comp-key-default.go
@@ -1,6 +1,3 @@
-//go:build !tinygo
-// +build !tinygo
-
 package vugu
 
 // CompKey is the key used to identify and look up a component instance.

--- a/v2/misc-default.go
+++ b/v2/misc-default.go
@@ -1,5 +1,3 @@
-//go:build !tinygo
-
 package vugu
 
 import "reflect"

--- a/v2/mod-check-default.go
+++ b/v2/mod-check-default.go
@@ -1,5 +1,3 @@
-//go:build !tinygo
-
 package vugu
 
 import (


### PR DESCRIPTION
Remove unused tinygo build tags (//go:build !tinygo).

Tinygo is not supported by the v2 module.