### PR TITLE
v2 - rewrite gen/parser-go-pkg.go and tests, bumps minimum Go version

### DIFF
--- a/v2/README.md
+++ b/v2/README.md
@@ -24,14 +24,15 @@ The list of changes are:
 - [x] Delete the `vgfrom` package and wasm test `test-020-vgform`
 - [x] Delete the `vuggen` command. Use `vugu gen` instead.
 - [x] Stop the `vugu gen` creating a `main_wasm.go`. This is a behaviour breaking change. Use `vugu init` to create the initial `main_wasm.go`.
-- [x] remove the `js` package by splitting the `VGNode` type. This removes the need to maintain a pseudo `syscall/js` type package for vugu.
-- [x] remove the unused `internal/htmlx` package
-- [x] remove mentions of the `legacytestsuite` from the magefiles
-- [x] remove any support of building the generated code with `tinygo`. This removes the `--tinygo` option from `vugu gen`
-- [ ] remove support for `<script "application/x-go">` tags in the `*.vugu` files. Use a proper component instead
-- [x] remove auto generating a `0_missing_gen.go` file that contains "missing" Go structs i.e. vugu components. This is unnecessary. ***This is a breaking change***
-- [x] remove support for producing a single merged file with all components. This removes the `-s` option from `vugu gen`
-- [x] remove support for the `--skip-go-mod` option from `vugu gen`.
+- [x] Remove the `js` package by splitting the `VGNode` type. This removes the need to maintain a pseudo `syscall/js` type package for vugu.
+- [x] Remove the unused `internal/htmlx` package
+- [x] Remove mentions of the `legacytestsuite` from the magefiles
+- [x] Remove any support of building the generated code with `tinygo`. This removes the `--tinygo` option from `vugu gen`
+- [ ] Remove support for `<script "application/x-go">` tags in the `*.vugu` files. Use a proper component instead
+- [x] Remove auto generating a `0_missing_gen.go` file that contains "missing" Go structs i.e. vugu components. This is unnecessary. ***This is a breaking change***
+- [x] Remove support for producing a single merged file with all components. This removes the `-s` option from `vugu gen`
+- [x] Remove support for the `--skip-go-mod` option from `vugu gen`.
+- [x] Completely rewrite `gen/parser-go-pkg.go` and associated tests to simplify the code. Flow changes into the `vugu gen` command. This removes the recursive `-r` switch from `vugu gen`. ***This is a breaking change***. `vugu gen` will now (re)generate a `*_gen_js_was,.go` file for every pair of `component.go` and `component.vugu` files that it finds, starting from the current directory.
 
 The original v0.y.z Readme follows.
 

--- a/v2/cmd/vugu/gen/gen.go
+++ b/v2/cmd/vugu/gen/gen.go
@@ -34,11 +34,7 @@ func Gen(ctx context.Context, cmd *cli.Command) error {
 			return err
 		}
 
-		if Recursive {
-			err = gen.RunRecursive(pkgPath)
-		} else {
-			err = gen.Run(pkgPath)
-		}
+		err = gen.Generate(pkgPath)
 		if err != nil {
 			return err
 		}

--- a/v2/cmd/vugu/vugu.go
+++ b/v2/cmd/vugu/vugu.go
@@ -52,17 +52,9 @@ func main() {
 			{
 				Name:      "gen",
 				Aliases:   []string{"g"},
-				Usage:     "Generate the Go code from the .vugu files in the directory",
+				Usage:     "Recursively generate the Go code from all of the .vugu files rooted in this directory",
 				ArgsUsage: "[OPTIONS] DIRECTORY",
-				Flags: []cli.Flag{
-					&cli.BoolFlag{
-						Name:        "r",
-						Value:       false,
-						Usage:       "Run recursively on specified path and subdirectories.",
-						Destination: &gen.Recursive,
-					},
-				},
-				Action: gen.Gen,
+				Action:    gen.Gen,
 			},
 			{
 				Name:      "init",

--- a/v2/examples/compound-component/go.mod
+++ b/v2/examples/compound-component/go.mod
@@ -2,7 +2,7 @@ module github.com/vugu/vugu/v2/examples/compound-component
 
 replace github.com/vugu/vugu/v2 => ../..
 
-go 1.23
+go 1.25.0
 
 require (
 	github.com/vugu/vjson v0.0.0-20200505061711-f9cbed27d3d9

--- a/v2/examples/dom-events/go.mod
+++ b/v2/examples/dom-events/go.mod
@@ -2,7 +2,7 @@ module github.com/vugu/vugu/v2/examples/dom-events
 
 replace github.com/vugu/vugu/v2 => ../..
 
-go 1.23
+go 1.25.0
 
 require (
 	github.com/vugu/vjson v0.0.0-20200505061711-f9cbed27d3d9

--- a/v2/examples/embed-and-translate/go.mod
+++ b/v2/examples/embed-and-translate/go.mod
@@ -2,7 +2,7 @@ module github.com/vugu/vugu/v2/examples/embed-and-translate
 
 replace github.com/vugu/vugu/v2 => ../..
 
-go 1.22.3
+go 1.25.0
 
 require (
 	github.com/nicksnyder/go-i18n/v2 v2.5.1

--- a/v2/examples/html-form/go.mod
+++ b/v2/examples/html-form/go.mod
@@ -2,7 +2,7 @@ module github.com/vugu/vugu/v2/examples/html-form
 
 replace github.com/vugu/vugu/v2 => ../..
 
-go 1.23
+go 1.25.0
 
 require (
 	github.com/vugu/vjson v0.0.0-20200505061711-f9cbed27d3d9

--- a/v2/examples/simple/go.mod
+++ b/v2/examples/simple/go.mod
@@ -2,7 +2,7 @@ module github.com/vugu/vugu/v2/examples/simple
 
 replace github.com/vugu/vugu/v2 => ../..
 
-go 1.22.3
+go 1.25.0
 
 require (
 	github.com/vugu/vjson v0.0.0-20200505061711-f9cbed27d3d9

--- a/v2/examples/vg-for/go.mod
+++ b/v2/examples/vg-for/go.mod
@@ -2,7 +2,7 @@ module github.com/vugu/vugu/v2/examples/vg-for
 
 replace github.com/vugu/vugu/v2 => ../..
 
-go 1.23
+go 1.25.0
 
 require (
 	github.com/vugu/vjson v0.0.0-20200505061711-f9cbed27d3d9

--- a/v2/examples/vg-if/go.mod
+++ b/v2/examples/vg-if/go.mod
@@ -2,7 +2,7 @@ module github.com/vugu/vugu/v2/examples/vg-if
 
 replace github.com/vugu/vugu/v2 => ../..
 
-go 1.22.3
+go 1.25.0
 
 require (
 	github.com/vugu/vjson v0.0.0-20200505061711-f9cbed27d3d9

--- a/v2/gen/hidden_notwindows.go
+++ b/v2/gen/hidden_notwindows.go
@@ -2,6 +2,10 @@
 
 package gen
 
+import "path/filepath"
+
 func isHidden(filename string) (bool, error) {
-	return filename[0] == '.', nil
+	// strip any path so we just look at the base filename (including any extension)
+	base := filepath.Base(filename)
+	return base[0] == '.', nil
 }

--- a/v2/gen/hidden_windows.go
+++ b/v2/gen/hidden_windows.go
@@ -3,11 +3,14 @@
 package gen
 
 import (
+	"path/filepath"
 	"syscall"
 )
 
 func isHidden(filename string) (bool, error) {
-	pointer, err := syscall.UTF16PtrFromString(filename)
+	// strip any path so we just look at the base filename (including any extension)
+	base := filepath.Base(filename)
+	pointer, err := syscall.UTF16PtrFromString(base)
 	if err != nil {
 		return false, err
 	}

--- a/v2/gen/parser-go-pkg-hidden_notwindows_test.go
+++ b/v2/gen/parser-go-pkg-hidden_notwindows_test.go
@@ -1,0 +1,104 @@
+//go:build!windows
+
+package gen
+
+import (
+	"errors"
+	"maps" // NOTE use of the maps package requires go 1.23 (The go.mod has been upgraded to go 1.25.0)
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParserHidden(t *testing.T) {
+	debug := true
+
+	pwd, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type tcase struct {
+		name    string
+		infiles map[string]string   // file structure to start with
+		out     map[string][]string // regexps to match in output files
+		bfiles  map[string]string   // additional files to write before building
+	}
+
+	tcList := []tcase{
+		{
+			name: "hidden_file",
+			infiles: map[string]string{
+				".root.vugu": `<div>root here</div>`, // make this a hidden file
+				"root.go":    "package main\ntype Root struct {\n}\n",
+				"go.mod":     "module testcase\nreplace github.com/vugu/vugu/v2 => " + pwd + "\n",
+				"main.go":    "//go:build js && wasm\n\npackage main\nfunc main(){}",
+			},
+			out: map[string][]string{
+				".root_gen_js_wasm.go": nil,
+				"root_gen_js_wasm.go":  nil,
+			},
+		},
+		{
+			name: "hidden_file_in_subdir",
+			infiles: map[string]string{
+				"root.vugu":            `<div>root here</div>`,             // make this a hidden file
+				"root.go":              "package\ntype Root struct {\n}\n", // this is invalid because there is no package name
+				"go.mod":               "module testcase\nreplace github.com/vugu/vugu/v2 => " + pwd + "\n",
+				"main.go":              "//go:build js && wasm\n\npackage main\nfunc main(){}",
+				"subdir/.example.vugu": `<div>example here</div>`, // make this a hidden file
+				"subdir/example.go":    "package main\ntype Example struct {\n}\n",
+			},
+			out: map[string][]string{
+				"subdir/.example_gen_js_wasm.go": nil,
+				"subdir/example_gen_js_wasm.go":  nil,
+			},
+		},
+		{
+			name: "hidden_directory",
+			infiles: map[string]string{
+				"root.vugu":            `<div>root here</div>`,             // make this a hidden file
+				"root.go":              "package\ntype Root struct {\n}\n", // this is invalid because there is no package name
+				"go.mod":               "module testcase\nreplace github.com/vugu/vugu/v2 => " + pwd + "\n",
+				"main.go":              "//go:build js && wasm\n\npackage main\nfunc main(){}",
+				".subdir/example.vugu": `<div>example here</div>`, // file in a hidden directory
+				".subdir/example.go":   "package main\ntype Example struct {\n}\n",
+			},
+			out: map[string][]string{
+				".subdir/example_gen_js_wasm.go": nil,
+			},
+		},
+	}
+
+	for _, tc := range tcList {
+		t.Run(tc.name, func(t *testing.T) {
+
+			tmpDir, err := os.MkdirTemp("", "TestRun")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if debug {
+				t.Logf("Test %q using tmpDir: %s", tc.name, tmpDir)
+			} else {
+				t.Parallel()
+			}
+
+			tstWriteFiles(tmpDir, tc.infiles)
+
+			err = Generate(tmpDir)
+
+			for key := range maps.Keys(tc.out) {
+				_, err = os.Stat(filepath.Join(tmpDir, key))
+				if !errors.Is(err, os.ErrNotExist) {
+					t.Fatalf("Did not expect to generate: %q", filepath.Join(tmpDir, key))
+				}
+			}
+			// only if everything is golden do we remove
+			if !t.Failed() {
+				os.RemoveAll(tmpDir)
+			}
+		})
+	}
+
+}

--- a/v2/gen/parser-go-pkg.go
+++ b/v2/gen/parser-go-pkg.go
@@ -4,181 +4,126 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"go/ast"
 	"go/parser"
 	"go/token"
+	"io/fs"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 )
 
-// ParserGoPkg knows how to perform source file generation in relation to a package folder.
-// Whereas ParserGo handles converting a single template, ParserGoPkg is a higher level interface
-// and provides the functionality of the vugu gen command line tool.  It will scan a package
-// folder for .vugu files and convert them to .go, with the appropriate defaults and logic.
-type ParserGoPkg struct {
-	pkgPath string
+const vuguExt = ".vugu"
+const goExt = ".go"
+const genExt = "_gen_js_wasm.go"
+
+// A ErrNoComponentGoFile error is returned when the corresponding <component>.go file cannot be found in the same directory
+// as the <component>.vugu file.
+var ErrNoComponentGoFile = errors.New("no corresponding go file found")
+
+// A ErrCouldNotParseVuguFile is returned when the <component>.vugu file cannot be parsed for any reason
+var ErrCouldNotParseVuguFile = errors.New("could not parse .vugu file")
+
+// A ErrCouldNotDeterminePackage is returned when the <component.go> file has been found but does not contain a valid package statement.
+var ErrCouldNotDeterminePackage = errors.New("could not determine package from .go file")
+
+// Generate will recursively turn each <component>.vugu file it finds into it's corresponding <component>_gen_js_wasm.go file
+// starting from the directory supplied in the pkgPath parameter. Generate expects to find a <component>.go file in the same directory as the
+// <component>.vugu file, and will place the <component>_gen_js_wasm.go file in the same directory.
+//
+// Any errors in this process are returned.
+// If no vugu files are found no changes will be made. This is not considered an error condition.
+//
+// Generate will return any error returned by walkFunc.
+// If a <component>.go file cannot be found [ErrNoComponentGoFile] will be returned
+// If a <component>.vugu file cannot be parsed successfully [ErrCouldNotParseVuguFile] will be returned
+// If the package cannot be determined from the <component>.go ErrCouldNotDeterminePackage will be returned.
+// Any other error i.e. [os.PathError] comes from the underlying OS.
+func Generate(pkgPath string) error {
+	return filepath.WalkDir(pkgPath, walkFunc)
 }
 
-var errNoVuguFile = errors.New("no .vugu file(s) found")
-
-// RunRecursive will create a new ParserGoPkg and call Run on it recursively for each
-// directory under pkgPath. If pkgPath does not contain a .vugu file this function will return an error.
-func RunRecursive(pkgPath string) error {
-
-	dirf, err := os.Open(pkgPath)
+// walkFunc is called by [Generate] for each file starting
+// As per [fs.WalkDirFunc] path is the full path filename (inc. directory(s) and file extension if any)
+func walkFunc(path string, d fs.DirEntry, err error) error {
+	// As per [fs.WalkDirFunc] walkFunc is called, with an error it is treated as a fatal error
 	if err != nil {
-		return err
+		return fmt.Errorf("could not read directory: %w\n", err)
 	}
 
-	fis, err := dirf.ReadDir(-1) // -1 returns all file names in the directory
-	if err != nil {
-		return err
+	// check if we are called with a hidden file or directory
+	hidden, herr := isHidden(path)
+	if herr != nil {
+		return herr
 	}
-	hasVugu := false
-	var subDirList []string
-	for _, fi := range fis {
-		// add sub dirs to a list, if they are not hidden sub dirs - needs a windows version!
-		hidden, err := isHidden(fi.Name())
-		if err != nil {
-			return err
-		}
-		if fi.IsDir() && !hidden {
-			subDirList = append(subDirList, fi.Name())
-			continue
-		}
-		if filepath.Ext(fi.Name()) == ".vugu" {
-			hasVugu = true
-		}
+	// skip hidden directories completely
+	if d.IsDir() && hidden {
+		return fs.SkipDir
 	}
-	if !hasVugu {
-		return errNoVuguFile
+	// skip hidden files
+	if hidden {
+		return nil
 	}
-
-	err = Run(pkgPath)
-	if err != nil {
-		return err
-	}
-
-	for _, subDir := range subDirList {
-		subPath := filepath.Join(pkgPath, subDir)
-		err := RunRecursive(subPath)
-		if err == errNoVuguFile {
-			continue
+	// do we have a *.vugu file
+	if !d.IsDir() && filepath.Ext(path) == vuguExt {
+		// we do. Now we need to find a *.go file in the same place
+		filenameNoExt := strings.TrimSuffix(path, vuguExt)
+		goFilename := filenameNoExt + goExt
+		// stat it to check it exists
+		_, serr := os.Stat(goFilename)
+		if serr != nil {
+			return fmt.Errorf("%v: %w", path, ErrNoComponentGoFile)
 		}
-		if err != nil {
-			return err
+		// at this point we know the component.go file must exist this means ParseFile CANNOT fail because of a missing component.go file
+		// generate the *_gen_js_wasm.go" filename by parsing it
+		genFileName := filenameNoExt + genExt
+		perr := ParseFile(path, goFilename, genFileName)
+		if perr != nil {
+			return fmt.Errorf("%v: %w\n", path, perr)
 		}
 	}
-
 	return nil
 }
 
-// Run will create a new ParserGoPkg and call Run on it.
-func Run(pkgPath string) error {
-	p := NewParserGoPkg(pkgPath)
-	return p.Run()
-}
-
-// NewParserGoPkg returns a new ParserGoPkg with the specified options or default if nil.  The pkgPath is required and must be an absolute path.
-func NewParserGoPkg(pkgPath string) *ParserGoPkg {
-	ret := &ParserGoPkg{
-		pkgPath: pkgPath,
-	}
-	return ret
-}
-
-// Run does the work and generates the appropriate .go files from .vugu files.
-// if package already has file with package name something other than main).
+// Run does the work and generates the appropriate _gen_js_wasm.go files from .vugu files.
 // Per-file code generation is performed by ParserGo.
-func (p *ParserGoPkg) Run() error {
-
-	pkgF, err := os.Open(p.pkgPath)
+func ParseFile(vuguFilename, goFilename, genFilename string) error {
+	// read the package name form the corresponding .go file
+	// the .go file already exists because [walkFunc] stat'd it
+	pkgName, err := findPackage(goFilename)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w: %w", ErrCouldNotDeterminePackage, err)
 	}
-	defer pkgF.Close()
 
-	allFileNames, err := pkgF.Readdirnames(-1)
+	compTypeName := fnameToGoTypeName(filepath.Base(vuguFilename))
+
+	pg := &ParserGo{}
+
+	pg.PackageName = pkgName
+	// pg.ComponentType = compTypeName
+	pg.StructType = compTypeName
+	// pg.DataType = pg.ComponentType + "Data"
+	pg.OutFile = genFilename
+
+	// read in source vugu file
+	b, err := os.ReadFile(vuguFilename)
 	if err != nil {
-		return err
-	}
-
-	var vuguFileNames []string
-	for _, fn := range allFileNames {
-		if filepath.Ext(fn) == ".vugu" {
-			vuguFileNames = append(vuguFileNames, fn)
-		}
-	}
-
-	if len(vuguFileNames) == 0 {
-		return fmt.Errorf("no .vugu files found, please create one and try again")
-	}
-
-	pkgName := goGuessPkgName(p.pkgPath)
-
-	namesToCheck := []string{"main"}
-
-	goFnameAppend := "_gen_js_wasm"
-
-	var mergeFiles []string
-
-	missingFmap := make(map[string]string, len(vuguFileNames))
-
-	// run ParserGo on each file to generate the .go files
-	for _, fn := range vuguFileNames {
-
-		baseFileName := strings.TrimSuffix(fn, ".vugu")
-		goFileName := baseFileName + goFnameAppend + ".go"
-		compTypeName := fnameToGoTypeName(baseFileName)
-
-		// keep track of which files to scan for missing structs
-		missingFmap[fn] = goFileName
-
-		mergeFiles = append(mergeFiles, goFileName)
-
-		pg := &ParserGo{}
-
-		pg.PackageName = pkgName
-		// pg.ComponentType = compTypeName
-		pg.StructType = compTypeName
-		// pg.DataType = pg.ComponentType + "Data"
-		pg.OutDir = p.pkgPath
-		pg.OutFile = goFileName
-
-		// add to our list of names to check after
-		namesToCheck = append(namesToCheck, pg.StructType)
-		// namesToCheck = append(namesToCheck, pg.ComponentType+".NewData")
-		// namesToCheck = append(namesToCheck, pg.DataType)
-		namesToCheck = append(namesToCheck, "vuguSetup")
-
-		// read in source
-		b, err := os.ReadFile(filepath.Join(p.pkgPath, fn))
-		if err != nil {
-			return err
-		}
-
-		// parse it
-		err = pg.Parse(bytes.NewReader(b), fn)
-		if err != nil {
-			return fmt.Errorf("error parsing %q: %v", fn, err)
-		}
-
-	}
-
-	// after the code generation is done, check the package for the various names in question to see
-	// what we need to generate
-	_, err = goPkgCheckNames(p.pkgPath, namesToCheck)
-	if err != nil {
+		fmt.Printf("ParserGoPkg.Run ReadFile error: %s\n", err)
 		return err
 	}
 
-	return nil
-
+	// parse the vugu file
+	err = pg.Parse(bytes.NewReader(b), vuguFilename)
+	if err != nil {
+		fmt.Printf("Parse returned: %v\n", err)
+		return fmt.Errorf("%w: %w\n", ErrCouldNotParseVuguFile, err)
+	}
+	return err
 }
 
 func fnameToGoTypeName(s string) string {
+	// Careful: this is making an assumption that we only take the portion of the filename up to the first period.
+	// so file.name.vugu will turn into a Go struct name of "File"
+	// This probally needs to be made clear in any docs.
 	s = strings.Split(s, ".")[0] // remove file extension if present
 	parts := strings.Split(s, "-")
 	for i := range parts {
@@ -191,139 +136,19 @@ func fnameToGoTypeName(s string) string {
 	return strings.Join(parts, "")
 }
 
-func goGuessPkgName(pkgPath string) (ret string) {
+func findPackage(goFile string) (string, error) {
+	// the *.vugu and the *.go should exist in the same directory. [walkFunc] will have confirmed the later already.
+	// The *.go contains the package name in the package statement, so use the Go ast to parse it out.
+	fset := token.NewFileSet() // positions are relative to fset
 
-	// defer func() { log.Printf("goGuessPkgName returning %q", ret) }()
-
-	// see if the package already has a name and use it if so
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseDir(fset, pkgPath, nil, parser.PackageClauseOnly) // just get the package name
+	// Parse src but stop after processing the imports.
+	// As per the [parser.ParseFile] docs, we will never see the case where f is nil and err is not nil because
+	// we know for sure that the goFile exists already. This means that any error returned by [parser.ParseFile]
+	// must relate to a syntax error (and by implication f will be non nil).
+	f, err := parser.ParseFile(fset, goFile, nil, parser.PackageClauseOnly|parser.SkipObjectResolution)
 	if err != nil {
-		goto checkMore
-	}
-	if len(pkgs) != 1 {
-		goto checkMore
-	}
-	{
-		var pkg *ast.Package //nolint:staticcheck // ast.Package is deprecated as of Go 1.23
-		for _, pkg1 := range pkgs {
-			pkg = pkg1
-		}
-		return pkg.Name
+		return "", err
 	}
 
-checkMore:
-
-	// check for a root.vugu file, in which case we assume "main"
-	_, err = os.Stat(filepath.Join(pkgPath, "root.vugu"))
-	if err == nil {
-		return "main"
-	}
-
-	// otherwise we use the name of the folder...
-	dirBase := filepath.Base(pkgPath)
-	if regexp.MustCompile(`^[a-z0-9]+$`).MatchString(dirBase) {
-		return dirBase
-	}
-
-	// ...unless it makes no sense in which case we use "main"
-
-	return "main"
-
-}
-
-// goPkgCheckNames parses a package dir and looks for names, returning a map of what was
-// found.  Names like "A.B" mean a method of name "B" with receiver of type "*A"
-func goPkgCheckNames(pkgPath string, names []string) (map[string]any, error) {
-
-	ret := make(map[string]any)
-
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseDir(fset, pkgPath, nil, 0)
-	if err != nil {
-		return ret, err
-	}
-
-	if len(pkgs) != 1 {
-		return ret, fmt.Errorf("unexpected package count after parsing, expected 1 and got this: %#v", pkgs)
-	}
-	var pkg *ast.Package //nolint:staticcheck // ast.Package is deprecated as of Go 1.23
-	for _, pkg1 := range pkgs {
-		pkg = pkg1
-	}
-
-	for _, file := range pkg.Files {
-
-		if file.Scope != nil {
-			for _, n := range names {
-				if v, ok := file.Scope.Objects[n]; ok {
-					ret[n] = v
-				}
-			}
-		}
-
-		// log.Printf("file: %#v", file)
-		// log.Printf("file.Scope.Objects: %#v", file.Scope.Objects)
-		// log.Printf("next: %#v", file.Scope.Objects["Example1"])
-		// e1 := file.Scope.Objects["Example1"]
-		// if e1.Kind == ast.Typ {
-		// e1.Decl
-		// }
-		for _, d := range file.Decls {
-			if fd, ok := d.(*ast.FuncDecl); ok {
-
-				var drecv, dmethod string
-				if fd.Recv != nil {
-					for _, f := range fd.Recv.List {
-						// log.Printf("f.Type: %#v", f.Type)
-						if tstar, ok := f.Type.(*ast.StarExpr); ok {
-							// log.Printf("tstar.X: %#v", tstar.X)
-							if tstarXi, ok := tstar.X.(*ast.Ident); ok && tstarXi != nil {
-								// log.Printf("namenamenamename: %#v", tstarXi.Name)
-								drecv = tstarXi.Name
-							}
-						}
-						// log.Printf("f.Names: %#v", f.Names)
-						// for _, fn := range f.Names {
-						// 	if fn != nil {
-						// 		log.Printf("NAMENAME: %#v", fn.Name)
-						// 		if fni, ok := fn.Name.(*ast.Ident); ok && fni != nil {
-						// 		}
-						// 	}
-						// }
-
-					}
-				} else {
-					continue // don't care methods with no receiver - found them already above as single (no period) names
-				}
-
-				// log.Printf("fd.Name: %#v", fd.Name)
-				if fd.Name != nil {
-					dmethod = fd.Name.Name
-				}
-
-				for _, n := range names {
-					recv, method := nameParts(n)
-					if drecv == recv && dmethod == method {
-						ret[n] = d
-					}
-				}
-			}
-		}
-	}
-	// log.Printf("Objects: %#v", pkg.Scope.Objects)
-
-	return ret, nil
-}
-
-func nameParts(n string) (recv, method string) {
-
-	ret := strings.SplitN(n, ".", 2)
-	if len(ret) < 2 {
-		method = n
-		return
-	}
-	recv = ret[0]
-	method = ret[1]
-	return
+	return f.Name.Name, nil
 }

--- a/v2/gen/parser-go-pkg_test.go
+++ b/v2/gen/parser-go-pkg_test.go
@@ -2,6 +2,7 @@ package gen
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -20,7 +21,7 @@ func TestSimpleParseGoPkgRun(t *testing.T) {
 		t.Fatal(err)
 	}
 	fmt.Printf("Dir: %s\n", tmpDir)
-	defer os.RemoveAll(tmpDir)
+	//	defer os.RemoveAll(tmpDir)
 
 	assert.NoError(os.WriteFile(filepath.Join(tmpDir, "root.vugu"), []byte(`
 <div id="root_comp">
@@ -28,16 +29,13 @@ func TestSimpleParseGoPkgRun(t *testing.T) {
 </div>
 `), 0644))
 
-	assert.NoError(os.WriteFile(filepath.Join(tmpDir, "root.go"), []byte(`
-package main
+	assert.NoError(os.WriteFile(filepath.Join(tmpDir, "root.go"), []byte(`package main
 
 type Root struct {
 }
 `), 0644))
 
-	p := NewParserGoPkg(tmpDir)
-
-	assert.NoError(p.Run())
+	assert.NoError(Generate(tmpDir))
 
 	b, err := os.ReadFile(filepath.Join(tmpDir, "root_gen_js_wasm.go"))
 	assert.NoError(err)
@@ -56,19 +54,15 @@ func TestRun(t *testing.T) {
 	}
 
 	type tcase struct {
-		name      string
-		recursive bool
-		infiles   map[string]string              // file structure to start with
-		out       map[string][]string            // regexps to match in output files
-		afterRun  func(dir string, t *testing.T) // called after Run
-		bfiles    map[string]string              // additional files to write before building
-		build     string                         // "wasm", "default", "none"
+		name    string
+		infiles map[string]string   // file structure to start with
+		out     map[string][]string // regexps to match in output files
+		bfiles  map[string]string   // additional files to write before building
 	}
 
 	tcList := []tcase{
 		{
-			name:      "simple",
-			recursive: false,
+			name: "simple",
 			infiles: map[string]string{
 				"root.vugu": `<div>root here</div>`,
 				"root.go":   "package main\ntype Root struct {\n}\n",
@@ -78,41 +72,9 @@ func TestRun(t *testing.T) {
 			out: map[string][]string{
 				"root_gen_js_wasm.go": {`func \(c \*Root\) Build`},
 			},
-			build: "wasm",
 		},
 		{
-			name:      "simple-wasm",
-			recursive: false,
-			infiles: map[string]string{
-				"root.vugu": `<div>root here</div>`,
-				"root.go":   "package main\ntype Root struct {\n}\n",
-				"go.mod":    "module testcase\nreplace github.com/vugu/vugu/v2 => " + pwd + "\n",
-				"main.go":   "//go:build js && wasm\n\npackage main\nfunc main(){}",
-			},
-			out: map[string][]string{
-				"root_gen_js_wasm.go": {`func \(c \*Root\) Build`},
-			},
-			build: "wasm",
-		},
-		{
-			name:      "recursive",
-			recursive: true,
-			infiles: map[string]string{
-				"root.vugu":            `<div>root here</div>`,
-				"root.go":              "package main\ntype Root struct {\n}\n",
-				"go.mod":               "module testcase\nreplace github.com/vugu/vugu/v2 => " + pwd + "\n",
-				"main.go":              "//go:build js && wasm\n\npackage main\nfunc main(){}",
-				"subdir1/example.vugu": "<div>Example Here</div>",
-			},
-			out: map[string][]string{
-				"root_gen_js_wasm.go":            {`func \(c \*Root\) Build`, `root here`},
-				"subdir1/example_gen_js_wasm.go": {"Example Here"},
-			},
-			build: "wasm",
-		},
-		{
-			name:      "recursive-single",
-			recursive: true,
+			name: "recursive",
 			infiles: map[string]string{
 				"root.vugu":            `<div>root here</div>`,
 				"root.go":              "package main\ntype Root struct {\n}\n",
@@ -122,12 +84,9 @@ func TestRun(t *testing.T) {
 				"subdir1/example.go":   "package main\ntype Example struct {\n}\n",
 			},
 			out: map[string][]string{
-				"root_gen_js_wasm.go":            {`func \(c \*Root\) Build`},
-				"subdir1/example_gen_js_wasm.go": {`func \(c \*Example\) Build`, "Example Here"},
-				"root.vugu":                      {`root here`}, // make sure vugu files didn't get nuked
-				"subdir1/example.vugu":           {`Example Here`},
+				"root_gen_js_wasm.go":            {`func \(c \*Root\) Build`, `root here`},
+				"subdir1/example_gen_js_wasm.go": {"Example Here"},
 			},
-			build: "wasm",
 		},
 	}
 
@@ -147,11 +106,7 @@ func TestRun(t *testing.T) {
 
 			tstWriteFiles(tmpDir, tc.infiles)
 
-			if tc.recursive {
-				err = RunRecursive(tmpDir)
-			} else {
-				err = Run(tmpDir)
-			}
+			err = Generate(tmpDir)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -171,10 +126,6 @@ func TestRun(t *testing.T) {
 				}
 			}
 
-			if tc.afterRun != nil {
-				tc.afterRun(tmpDir, t)
-			}
-
 			tstWriteFiles(tmpDir, tc.bfiles)
 
 			cmd := exec.Command("go", "mod", "tidy")
@@ -184,22 +135,13 @@ func TestRun(t *testing.T) {
 				t.Fatalf("go mod tidy error: %s; OUTPUT:\n%s", err, b)
 			}
 
-			switch tc.build {
-
-			case "wasm":
-				cmd := exec.Command("go", "build", "-o", "main.wasm", ".")
-				cmd.Dir = tmpDir
-				cmd.Env = os.Environ() // needed?
-				cmd.Env = append(cmd.Env, "GOOS=js", "GOARCH=wasm")
-				b, err := cmd.CombinedOutput()
-				if err != nil {
-					t.Fatalf("build error: %s; OUTPUT:\n%s", err, b)
-				}
-
-			case "none":
-
-			default:
-				t.Errorf("unknown build value %q", tc.build)
+			cmd = exec.Command("go", "build", "-o", "main.wasm", ".")
+			cmd.Dir = tmpDir
+			cmd.Env = os.Environ() // needed?
+			cmd.Env = append(cmd.Env, "GOOS=js", "GOARCH=wasm")
+			b, err = cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("build error: %s; OUTPUT:\n%s", err, b)
 			}
 
 			// only if everything is golden do we remove
@@ -212,11 +154,125 @@ func TestRun(t *testing.T) {
 
 }
 
-func noFile(p string, t *testing.T) {
-	_, err := os.Stat(p)
-	if err == nil {
-		t.Errorf("file %q should not exist but does", p)
+func TestMissingComponentGoFile(t *testing.T) {
+	debug := true
+
+	pwd, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
 	}
+
+	type tcase struct {
+		name    string
+		infiles map[string]string   // file structure to start with
+		out     map[string][]string // regexps to match in output files
+		bfiles  map[string]string   // additional files to write before building
+	}
+
+	tcList := []tcase{
+		{
+			name: "missing-go-file",
+			infiles: map[string]string{
+				"root.vugu": `<div>root here</div>`,
+				"go.mod":    "module testcase\nreplace github.com/vugu/vugu/v2 => " + pwd + "\n",
+				"main.go":   "//go:build js && wasm\n\npackage main\nfunc main(){}",
+			},
+		},
+		{
+			name: "incorrectly-named-go-file",
+			infiles: map[string]string{
+				"root.vugu": `<div>root here</div>`,
+				"roots.go":  "package main\ntype Root struct{}\n",
+				"go.mod":    "module testcase\nreplace github.com/vugu/vugu/v2 => " + pwd + "\n",
+				"main.go":   "//go:build js && wasm\n\npackage main\nfunc main(){}",
+			},
+		},
+	}
+
+	for _, tc := range tcList {
+		t.Run(tc.name, func(t *testing.T) {
+
+			tmpDir, err := os.MkdirTemp("", "TestRun")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if debug {
+				t.Logf("Test %q using tmpDir: %s", tc.name, tmpDir)
+			} else {
+				t.Parallel()
+			}
+
+			tstWriteFiles(tmpDir, tc.infiles)
+
+			err = Generate(tmpDir)
+			if !errors.Is(err, ErrNoComponentGoFile) {
+				t.Fatalf("Expected an ErrNoComponentGoFile but got: %v\n", err)
+			}
+			// only if everything is golden do we remove
+			if !t.Failed() {
+				os.RemoveAll(tmpDir)
+			}
+		})
+	}
+
+}
+
+func TestParserErrors(t *testing.T) {
+	debug := true
+
+	pwd, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type tcase struct {
+		name    string
+		infiles map[string]string   // file structure to start with
+		out     map[string][]string // regexps to match in output files
+		bfiles  map[string]string   // additional files to write before building
+	}
+
+	tcList := []tcase{
+		{
+			name: "simple",
+			infiles: map[string]string{
+				"root.vugu": `<div>root here</div>`,
+				"root.go":   "package\ntype Root struct {\n}\n", // this is invalid because there is no package name
+				"go.mod":    "module testcase\nreplace github.com/vugu/vugu/v2 => " + pwd + "\n",
+				"main.go":   "//go:build js && wasm\n\npackage main\nfunc main(){}",
+			},
+		},
+	}
+
+	for _, tc := range tcList {
+		t.Run(tc.name, func(t *testing.T) {
+
+			tmpDir, err := os.MkdirTemp("", "TestRun")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if debug {
+				t.Logf("Test %q using tmpDir: %s", tc.name, tmpDir)
+			} else {
+				t.Parallel()
+			}
+
+			tstWriteFiles(tmpDir, tc.infiles)
+
+			err = Generate(tmpDir)
+
+			if !errors.Is(err, ErrCouldNotDeterminePackage) {
+				t.Fatalf("Expected an ErrCouldNotDeterminePackage but got: %v\n", err)
+			}
+			// only if everything is golden do we remove
+			if !t.Failed() {
+				os.RemoveAll(tmpDir)
+			}
+		})
+	}
+
 }
 
 func tstWriteFiles(dir string, m map[string]string) {
@@ -225,10 +281,12 @@ func tstWriteFiles(dir string, m map[string]string) {
 		p := filepath.Join(dir, name)
 		err := os.MkdirAll(filepath.Dir(p), 0755)
 		if err != nil {
+			fmt.Printf("BEFORE PANIC new dir: %s\n", p)
 			panic(err)
 		}
 		err = os.WriteFile(p, []byte(contents), 0644)
 		if err != nil {
+			fmt.Printf("BEFORE PANIC new file %s contents %s\n", p, contents)
 			panic(err)
 		}
 	}

--- a/v2/gen/parser-go.go
+++ b/v2/gen/parser-go.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"sort"
 	"strings"
 	"unicode"
@@ -23,7 +22,6 @@ type ParserGo struct {
 	StructType  string // just the struct name, no "*" (replaces ComponentType and DataType)
 	// ComponentType string // just the struct name, no "*"
 	// DataType      string // just the struct name, no "*"
-	OutDir  string // output dir
 	OutFile string // output file name with ".go" suffix
 
 	NoOptimizeStatic bool // set to true to disable optimization of static blocks of HTML into vg-html expressions
@@ -76,6 +74,7 @@ func (p *ParserGo) Parse(r io.Reader, fname string) error {
 
 	inRaw, err := io.ReadAll(r)
 	if err != nil {
+		fmt.Printf("ReadAll filename: %s, Error: %s\n", fname, err)
 		return err
 	}
 
@@ -85,6 +84,8 @@ func (p *ParserGo) Parse(r io.Reader, fname string) error {
 	for {
 		tt := tmpZ.Next()
 		if tt == html.ErrorToken {
+			fmt.Printf("Tokenizer called with: \n%s\n", inRaw)
+			fmt.Printf("tmpZ token error: %s\n", tmpZ.Err())
 			return tmpZ.Err()
 		}
 		if tt != html.StartTagToken { // skip over non-tags
@@ -104,6 +105,7 @@ func (p *ParserGo) Parse(r io.Reader, fname string) error {
 
 		n, err := html.Parse(bytes.NewReader(inRaw))
 		if err != nil {
+			fmt.Printf("html.Parse error: %s\n", err)
 			return err
 		}
 		state.docNodeList = append(state.docNodeList, n) // docNodeList is just this one item
@@ -116,6 +118,7 @@ func (p *ParserGo) Parse(r io.Reader, fname string) error {
 			Data:     "div",
 		})
 		if err != nil {
+			fmt.Printf("html.ParseFragment error %s\n", err)
 			return err
 		}
 
@@ -136,6 +139,7 @@ func (p *ParserGo) Parse(r io.Reader, fname string) error {
 		for _, n := range state.docNodeList {
 			err = compactNodeTree(n)
 			if err != nil {
+				fmt.Printf("compact node tree error: %s\n", err)
 				return err
 			}
 		}
@@ -153,6 +157,7 @@ func (p *ParserGo) Parse(r io.Reader, fname string) error {
 
 	err = p.visitOverall(state)
 	if err != nil {
+		fmt.Printf("visitOverall error: %s\n", err)
 		return err
 	}
 
@@ -162,11 +167,11 @@ func (p *ParserGo) Parse(r io.Reader, fname string) error {
 	buf.Write(state.buildBuf.Bytes())
 	buf.Write(state.goBufBottom.Bytes())
 
-	outPath := filepath.Join(p.OutDir, p.OutFile)
+	outPath := p.OutFile
 
 	fo, err := gofmt(buf.String())
 	if err != nil {
-
+		fmt.Printf("GO FMT ERRORS WITH %s\n", err)
 		// if the gofmt errors, we still attempt to write out the non-fmt'ed output to the file, to assist in debugging
 		_ = os.WriteFile(outPath, buf.Bytes(), 0644)
 
@@ -177,16 +182,19 @@ func (p *ParserGo) Parse(r io.Reader, fname string) error {
 	var dedupedBuf bytes.Buffer
 	err = dedupImports(bytes.NewReader([]byte(fo)), &dedupedBuf, p.OutFile)
 	if err != nil {
+		fmt.Printf("failed to dedup: %s\n", err)
 		return err
 	}
 
 	// write to final output file
 	err = os.WriteFile(outPath, dedupedBuf.Bytes(), 0644)
 	if err != nil {
+		fmt.Printf("failed to write file: %s Error: %s\n", outPath, err)
 		return err
 	}
 	err = removeRedundantDefinitions(outPath)
 	if err != nil {
+		fmt.Printf("removeRedundantDefinitions error: %s\n", err)
 		return err
 	}
 	return nil

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -26,4 +26,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.22.3
+go 1.25.0

--- a/v2/wasm-test-suite/test-002-click/go.mod
+++ b/v2/wasm-test-suite/test-002-click/go.mod
@@ -2,9 +2,7 @@ module github.com/vugu/vugu/v2/wasm-test-suite/test-002-click
 
 replace github.com/vugu/vugu/v2 => ../..
 
-go 1.23
-
-toolchain go1.23.5
+go 1.25.0
 
 require (
 	github.com/chromedp/chromedp v0.12.1

--- a/v2/wasm-test-suite/test-005-issue-80/go.mod
+++ b/v2/wasm-test-suite/test-005-issue-80/go.mod
@@ -2,9 +2,7 @@ module github.com/vugu/vugu/v2/wasm-test-suite/test-005-issue-80
 
 replace github.com/vugu/vugu/v2 => ../..
 
-go 1.23
-
-toolchain go1.23.5
+go 1.25.0
 
 require (
 	github.com/chromedp/chromedp v0.12.1

--- a/v2/wasm-test-suite/test-006-issue-81/go.mod
+++ b/v2/wasm-test-suite/test-006-issue-81/go.mod
@@ -2,9 +2,7 @@ module github.com/vugu/vugu/v2/wasm-test-suite/test-006-issue-81
 
 replace github.com/vugu/vugu/v2 => ../..
 
-go 1.23
-
-toolchain go1.23.5
+go 1.25.0
 
 require (
 	github.com/chromedp/cdproto v0.0.0-20250126231910-1730200a0f74

--- a/v2/wasm-test-suite/test-007-issue-85/go.mod
+++ b/v2/wasm-test-suite/test-007-issue-85/go.mod
@@ -2,9 +2,7 @@ module github.com/vugu/vugu/v2/wasm-test-suite/test-007-issue-85
 
 replace github.com/vugu/vugu/v2 => ../..
 
-go 1.23
-
-toolchain go1.23.5
+go 1.25.0
 
 require (
 	github.com/chromedp/chromedp v0.12.1

--- a/v2/wasm-test-suite/test-008-for-i/go.mod
+++ b/v2/wasm-test-suite/test-008-for-i/go.mod
@@ -2,9 +2,7 @@ module github.com/vugu/vugu/v2/wasm-test-suite/test-008-for-i
 
 replace github.com/vugu/vugu/v2 => ../..
 
-go 1.23
-
-toolchain go1.23.5
+go 1.25.0
 
 require (
 	github.com/chromedp/chromedp v0.12.1

--- a/v2/wasm-test-suite/test-008-for-keyvalue/go.mod
+++ b/v2/wasm-test-suite/test-008-for-keyvalue/go.mod
@@ -2,9 +2,7 @@ module github.com/vugu/vugu/v2/wasm-test-suite/test-008-for-keyvalue
 
 replace github.com/vugu/vugu/v2 => ../..
 
-go 1.23
-
-toolchain go1.23.5
+go 1.25.0
 
 require (
 	github.com/chromedp/chromedp v0.12.1

--- a/v2/wasm-test-suite/test-008-for-kv/go.mod
+++ b/v2/wasm-test-suite/test-008-for-kv/go.mod
@@ -2,9 +2,7 @@ module github.com/vugu/vugu/v2/wasm-test-suite/test-008-for-kv
 
 replace github.com/vugu/vugu/v2 => ../..
 
-go 1.23
-
-toolchain go1.23.5
+go 1.25.0
 
 require (
 	github.com/chromedp/chromedp v0.12.1

--- a/v2/wasm-test-suite/test-009-trim-unused/go.mod
+++ b/v2/wasm-test-suite/test-009-trim-unused/go.mod
@@ -2,9 +2,7 @@ module github.com/vugu/vugu/v2/wasm-test-suite/test-009-trim-unused
 
 replace github.com/vugu/vugu/v2 => ../..
 
-go 1.23
-
-toolchain go1.23.5
+go 1.25.0
 
 require (
 	github.com/chromedp/chromedp v0.12.1

--- a/v2/wasm-test-suite/test-010-listener-readd/go.mod
+++ b/v2/wasm-test-suite/test-010-listener-readd/go.mod
@@ -2,9 +2,7 @@ module github.com/vugu/vugu/v2/wasm-test-suite/test-010-listener-readd
 
 replace github.com/vugu/vugu/v2 => ../..
 
-go 1.23
-
-toolchain go1.23.5
+go 1.25.0
 
 require (
 	github.com/chromedp/chromedp v0.12.1

--- a/v2/wasm-test-suite/test-011-wire/go.mod
+++ b/v2/wasm-test-suite/test-011-wire/go.mod
@@ -2,9 +2,7 @@ module github.com/vugu/vugu/v2/wasm-test-suite/test-011-wire
 
 replace github.com/vugu/vugu/v2 => ../..
 
-go 1.23
-
-toolchain go1.23.5
+go 1.25.0
 
 require (
 	github.com/chromedp/chromedp v0.12.1

--- a/v2/wasm-test-suite/test-012-router/go.mod
+++ b/v2/wasm-test-suite/test-012-router/go.mod
@@ -1,8 +1,6 @@
 module github.com/vugu/vugu/v2/wasm-test-suite/test-012-router
 
-go 1.23
-
-toolchain go1.23.5
+go 1.25.0
 
 replace github.com/vugu/vugu/v2 => ../..
 

--- a/v2/wasm-test-suite/test-013-issue-117/go.mod
+++ b/v2/wasm-test-suite/test-013-issue-117/go.mod
@@ -2,9 +2,7 @@ module github.com/vugu/vugu/v2/wasm-test-suite/test-013-issue-117
 
 replace github.com/vugu/vugu/v2 => ../..
 
-go 1.23
-
-toolchain go1.23.5
+go 1.25.0
 
 require (
 	github.com/chromedp/chromedp v0.12.1

--- a/v2/wasm-test-suite/test-014-attrintf/go.mod
+++ b/v2/wasm-test-suite/test-014-attrintf/go.mod
@@ -2,9 +2,7 @@ module github.com/vugu/vugu/v2/wasm-test-suite/test-014-attrintf
 
 replace github.com/vugu/vugu/v2 => ../..
 
-go 1.23
-
-toolchain go1.23.5
+go 1.25.0
 
 require (
 	github.com/chromedp/chromedp v0.12.1

--- a/v2/wasm-test-suite/test-015-attribute-lister/go.mod
+++ b/v2/wasm-test-suite/test-015-attribute-lister/go.mod
@@ -2,9 +2,7 @@ module github.com/vugu/vugu/v2/wasm-test-suite/test-015-attribute-lister
 
 replace github.com/vugu/vugu/v2 => ../..
 
-go 1.23
-
-toolchain go1.23.5
+go 1.25.0
 
 require (
 	github.com/chromedp/chromedp v0.12.1

--- a/v2/wasm-test-suite/test-016-svg/go.mod
+++ b/v2/wasm-test-suite/test-016-svg/go.mod
@@ -1,8 +1,6 @@
 module github.com/vugu/vugu/v2/wasm-test-suite/test-016-svg
 
-go 1.23
-
-toolchain go1.23.5
+go 1.25.0
 
 replace github.com/vugu/vugu/v2 => ../..
 

--- a/v2/wasm-test-suite/test-017-nesting/go.mod
+++ b/v2/wasm-test-suite/test-017-nesting/go.mod
@@ -1,8 +1,6 @@
 module github.com/vugu/vugu/v2/wasm-test-suite/test-017-nesting
 
-go 1.23
-
-toolchain go1.23.5
+go 1.25.0
 
 replace github.com/vugu/vugu/v2 => ../..
 

--- a/v2/wasm-test-suite/test-018-comp-events/go.mod
+++ b/v2/wasm-test-suite/test-018-comp-events/go.mod
@@ -1,8 +1,6 @@
 module github.com/vugu/vugu/v2/wasm-test-suite/test-018-comp-events
 
-go 1.23
-
-toolchain go1.23.5
+go 1.25.0
 
 replace github.com/vugu/vugu/v2 => ../..
 

--- a/v2/wasm-test-suite/test-019-js-create-populate/go.mod
+++ b/v2/wasm-test-suite/test-019-js-create-populate/go.mod
@@ -1,8 +1,6 @@
 module github.com/vugu/vugu/v2/wasm-test-suite/test-019-js-create-populate
 
-go 1.23
-
-toolchain go1.23.5
+go 1.25.0
 
 replace github.com/vugu/vugu/v2 => ../..
 

--- a/v2/wasm-test-suite/test-021-slots/go.mod
+++ b/v2/wasm-test-suite/test-021-slots/go.mod
@@ -1,8 +1,6 @@
 module github.com/vugu/vugu/v2/wasm-test-suite/test-021-slots
 
-go 1.23
-
-toolchain go1.23.5
+go 1.25.0
 
 replace github.com/vugu/vugu/v2 => ../..
 

--- a/v2/wasm-test-suite/test-022-event-listener/go.mod
+++ b/v2/wasm-test-suite/test-022-event-listener/go.mod
@@ -1,8 +1,6 @@
 module github.com/vugu/vugu/v2/wasm-test-suite/test-022-event-listener
 
-go 1.23
-
-toolchain go1.23.5
+go 1.25.0
 
 replace github.com/vugu/vugu/v2 => ../..
 

--- a/v2/wasm-test-suite/test-023-lifecycle-callbacks/go.mod
+++ b/v2/wasm-test-suite/test-023-lifecycle-callbacks/go.mod
@@ -1,8 +1,6 @@
 module github.com/vugu/vugu/v2/wasm-test-suite/test-023-lifecycle-callbacks
 
-go 1.23
-
-toolchain go1.23.5
+go 1.25.0
 
 replace github.com/vugu/vugu/v2 => ../..
 

--- a/v2/wasm-test-suite/test-024-event-buffer-size/go.mod
+++ b/v2/wasm-test-suite/test-024-event-buffer-size/go.mod
@@ -1,8 +1,6 @@
 module github.com/vugu/vugu/v2/wasm-test-suite/test-024-event-buffer-size
 
-go 1.23
-
-toolchain go1.23.5
+go 1.25.0
 
 replace github.com/vugu/vugu/v2 => ../..
 

--- a/v2/wasm-test-suite/test-025-valueof/go.mod
+++ b/v2/wasm-test-suite/test-025-valueof/go.mod
@@ -2,9 +2,7 @@ module github.com/vugu/vugu/v2/wasm-test-suite/test-025-valueof
 
 replace github.com/vugu/vugu/v2 => ../..
 
-go 1.23
-
-toolchain go1.23.5
+go 1.25.0
 
 require (
 	github.com/chromedp/chromedp v0.12.1


### PR DESCRIPTION
This is a complete rewrite on the gen/parser-go-pkg file and its tests. Any required changes have flowed into both gen/parser.go and the 'vugu gen' command.

gen/parser-go-pkg.go was written before Go 1.16. As a consequence it handled recursion directly. The approach to determining the package name involved using the depreciated ast.ParseDir function, a regex to examine the last part of the directory path and if all else failed defaulting to a package name of "main".

The new approach is based on the filepath.WalkDir function introduced in Go 1.16.

The approach is now very simple.

filepath.WalkDir is called from a directory. It recursively walks the directory tree looking for files called *.vugu.

For each *.vugu file it finds, it checks that a corresponding *.go file exists. A corresponding file is a file with the same base name in the same directory but with a .go extension rather than a .vugu extension.

If a pair is found, then the package is read directly from the *.go file by parsing it and reading the package name from the resulting Go AST. The *.vugu file is then parsed using ParserGo.ParseFile to generate the *_gen_js_wasm.go file.

The new approach is always recursive, so the 'vugu gen' -r option has now been removed.

Any required changes have been pushed upwards into the cmd/vugu package and across into the gen/parser-go.go file.

The gen/parser-go.go file is however largely untouched.

This change was only possible once the auto-generation of missing components had been removed beforehand. See commit #089701e

The new TestParserHidden test - which does not run on Windows - checks that hidden files and hidden directories are correctly ignored.

It ensures that Go files are not generated from hidden *.vugu files, or from files in hidden directories.

The present version is for Unix like OS's only.

TestParserHidden relies on the new maps package from go 1.23. This has caused the Go version of vugu to be bumped to 1.25.0 (the current old stable version). A consequence of this is that all of the wasm tests and examples now require Go 1.25.0 as a minimum version as well.