### PR TITLE
v2 - remove support for <script type="application/x-go"> tags

### DIFF
--- a/v2/README.md
+++ b/v2/README.md
@@ -28,7 +28,7 @@ The list of changes are:
 - [x] Remove the unused `internal/htmlx` package
 - [x] Remove mentions of the `legacytestsuite` from the magefiles
 - [x] Remove any support of building the generated code with `tinygo`. This removes the `--tinygo` option from `vugu gen`
-- [ ] Remove support for `<script "application/x-go">` tags in the `*.vugu` files. Use a proper component instead
+- [x] Remove support for `<script type="application/x-go">` tags in the `*.vugu` files. ***This is a breaking change***. All Go code should be in the `*.go` file that relates to the component. The `simple` example that used a `<script type="application/x-go">` has been updated to remove the use of the `<script type="application/x-go">` block. See the new `Root.After2020` function in the `simple` example.
 - [x] Remove auto generating a `0_missing_gen.go` file that contains "missing" Go structs i.e. vugu components. This is unnecessary. ***This is a breaking change***
 - [x] Remove support for producing a single merged file with all components. This removes the `-s` option from `vugu gen`
 - [x] Remove support for the `--skip-go-mod` option from `vugu gen`.

--- a/v2/examples/simple/root.go
+++ b/v2/examples/simple/root.go
@@ -1,7 +1,13 @@
 package main
 
+import "time"
+
 type Root struct {
 	ShowWasm bool `vugu:"data"`
 	ShowGo   bool `vugu:"data"`
 	ShowVugu bool `vugu:"data"`
+}
+
+func (r *Root) After2020() bool {
+	return time.Now().Year() >= 2020
 }

--- a/v2/examples/simple/root.vugu
+++ b/v2/examples/simple/root.vugu
@@ -26,7 +26,7 @@
             <div vg-if='c.ShowVugu' class="alert alert-primary" role="alert">
                 <strong>Vugu</strong> is a modern web UI library for Go+WebAssembly.
                 It is written in pure Go, works well in most modern browsers and supports 
-                <span vg-if='time.Now().Year()>=2020'>most</span> features one would expect from
+                <span vg-if='c.After2020()'>most</span> features one would expect from
                 a web framework.  It also makes a point of attempting to apply best practices 
                 from Go to web application UI development and prefers idiomatic solutions over
                 techniques that follow patterns from JavaScript wherever possible.
@@ -37,13 +37,3 @@
 
     </main>
 </div>
-
-<script type="application/x-go">
-
-// this import and enclosing <script> block ate BOTH necessary.
-// The HTML above calls time.Now().Year() directly.
-// So we must explicitly import the time package in the .vugu file.
-// otherwise the compilation will fail due to an unknown import.
-import "time"
-    
-</script>

--- a/v2/examples/simple/root_gen_js_wasm.go
+++ b/v2/examples/simple/root_gen_js_wasm.go
@@ -12,12 +12,6 @@ import "github.com/vugu/vugu/v2"
 import "syscall/js"
 import "log"
 
-// this import and enclosing <script> block ate BOTH necessary.
-// The HTML above calls time.Now().Year() directly.
-// So we must explicitly import the time package in the .vugu file.
-// otherwise the compilation will fail due to an unknown import.
-import "time"
-
 func (c *Root) Build(vgin *vugu.BuildIn) (vgout *vugu.BuildOut) {
 
 	vgout = &vugu.BuildOut{}
@@ -183,7 +177,7 @@ func (c *Root) Build(vgin *vugu.BuildIn) (vgout *vugu.BuildOut) {
 						vgn.SetInnerHTML(vugu.HTML("Vugu"))
 						vgn = &vugu.VGNode{VGNodeCommonCore: vugu.VGNodeCommonCore{Type: vugu.VGNodeType(1), Data: " is a modern web UI library for Go+WebAssembly.\n                It is written in pure Go, works well in most modern browsers and supports \n                "}}
 						vgparent.AppendChild(vgn)
-						if time.Now().Year() >= 2020 {
+						if c.After2020() {
 							vgn = &vugu.VGNode{VGNodeCommonCore: vugu.VGNodeCommonCore{Type: vugu.VGNodeType(3), Namespace: "", Data: "span", Attr: []vugu.VGAttribute(nil)}}
 							vgparent.AppendChild(vgn)
 							{

--- a/v2/gen/parser-go-pkg_test.go
+++ b/v2/gen/parser-go-pkg_test.go
@@ -278,6 +278,59 @@ func TestParserErrors(t *testing.T) {
 
 }
 
+func TestParserGoScriptTags(t *testing.T) {
+	debug := true
+
+	pwd, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type tcase struct {
+		name    string
+		infiles map[string]string   // file structure to start with
+		out     map[string][]string // regexps to match in output files
+		bfiles  map[string]string   // additional files to write before building
+	}
+
+	tcList := []tcase{
+		{
+			name: "Go-script-tags",
+			infiles: map[string]string{
+				"root.vugu": "<div>root here</div>\n<script type=\"application/x-go\">\nimport \"fmt\"\n</script>", // include a no longer supported script type="application/x-go> tag
+				"root.go":   "package main\ntype Root struct {\n}\n",
+				"go.mod":    "module testcase\nreplace github.com/vugu/vugu/v2 => " + pwd + "\n",
+				"main.go":   "//go:build js && wasm\n\npackage main\nfunc main(){}",
+			},
+		},
+	}
+
+	for _, tc := range tcList {
+		t.Run(tc.name, func(t *testing.T) {
+
+			tmpDir, err := os.MkdirTemp("", "TestParserGoScriptTag")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if debug {
+				t.Logf("Test %q using tmpDir: %s", tc.name, tmpDir)
+			} else {
+				t.Parallel()
+			}
+
+			tstWriteFiles(tmpDir, tc.infiles)
+
+			err = Generate(tmpDir)
+
+			if !errors.Is(err, ErrGoInScriptTag) {
+				t.Fatalf("Expected a ErrGoInScriptTag but got %s", err)
+			}
+		})
+	}
+
+}
+
 func tstWriteFiles(dir string, m map[string]string) {
 
 	for name, contents := range m {

--- a/v2/gen/parser-go.go
+++ b/v2/gen/parser-go.go
@@ -13,6 +13,8 @@ import (
 	"github.com/vugu/vugu/v2"
 )
 
+var ErrGoInScriptTag = errors.New("\"<script application/x-go>\" tags are no longer supported in a .vugu file.")
+
 // ParserGo is a template parser that emits Go source code that will construct the appropriately wired VGNodes.
 type ParserGo struct {
 	PackageName string // name of package to use at top of files
@@ -408,13 +410,10 @@ func (p *ParserGo) visitScriptOrStyle(state *parseGoState, n *html.Node) error {
 			mt = strings.Split(strings.TrimSpace(ty.Val), ";")[0]
 		}
 
-		// go code
+		// go code in script tags is now banned. Any code that was in a <script application/x-go> tag needs to be moved to the
+		// corresponding <component>.go file
 		if mt == "application/x-go" {
-			err := p.visitGo(state, n)
-			if err != nil {
-				return err
-			}
-			return nil
+			return fmt.Errorf("%w", ErrGoInScriptTag)
 		}
 
 		// component js (type attr omitted okay - means it is JS)
@@ -591,20 +590,6 @@ func (p *ParserGo) visitCSS(state *parseGoState, n *html.Node) error {
 
 	// dynamic attrs
 	writeDynamicAttributes(state, n)
-
-	return nil
-}
-
-func (p *ParserGo) visitGo(state *parseGoState, n *html.Node) error {
-	for childN := n.FirstChild; childN != nil; childN = childN.NextSibling {
-		if childN.Type != html.TextNode {
-			return fmt.Errorf("unexpected node type %v inside of script tag", childN.Type)
-		}
-		// if childN.Line > 0 {
-		// 	fmt.Fprintf(&goBuf, "//line %s:%d\n", fname, childN.Line)
-		// }
-		state.goBuf.WriteString(childN.Data)
-	}
 
 	return nil
 }


### PR DESCRIPTION
Support for <script type="application/x-go"> has been removed,

Supporting <script type="application/x-go"> now makes no sense. Go code that relates to a component should be placed in a <component-name>.go file where it can be tested etc. using he normal Go tools.

The developer already has to provide a <component-name>.go as it is no longer automatically generated if required. As a consequence it is trivial to move any code inside <script type="application/x-go"> tags into the <component-name>.go file.