### PR TITLE
Full html mode is broken - it fails to set the title or update <head>

### DIFF
--- a/wasm-test-suite/test-003-prop/go.mod
+++ b/wasm-test-suite/test-003-prop/go.mod
@@ -7,13 +7,13 @@ go 1.23
 toolchain go1.23.5
 
 require (
+	github.com/chromedp/cdproto v0.0.0-20250126231910-1730200a0f74
 	github.com/chromedp/chromedp v0.12.1
 	github.com/vugu/vjson v0.0.0-20200505061711-f9cbed27d3d9
 	github.com/vugu/vugu v0.4.0
 )
 
 require (
-	github.com/chromedp/cdproto v0.0.0-20250126231910-1730200a0f74 // indirect
 	github.com/chromedp/sysutil v1.1.0 // indirect
 	github.com/gobwas/httphead v0.1.0 // indirect
 	github.com/gobwas/pool v0.2.1 // indirect

--- a/wasm-test-suite/test-003-prop/main_test.go
+++ b/wasm-test-suite/test-003-prop/main_test.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"testing"
 
+	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/chromedp"
 
 	chromedpHelper "github.com/vugu/vugu/testing/chromedp"
@@ -31,4 +33,49 @@ func Test003Prop(t *testing.T) {
 		chromedpHelper.WaitInnerTextTrimEq("#emailout", "default@example.com"),
 	))
 
+}
+
+func Test003PropTitleChange(t *testing.T) {
+	pkgName := pkg.PkgName(t)
+	tmpl.CreateIndexHtml(t, pkgName)
+
+	url := "http://vugu-nginx/" + pkgName
+	log.Printf("URL: %s", url)
+
+	ctx, cancel := chromedpHelper.MustChromeCtx()
+	defer cancel()
+
+	title := ""
+	expectedTitle := "Test page"
+	chromedpHelper.Must(chromedp.Run(ctx,
+		chromedp.Navigate(url),
+		chromedp.Title(&title),
+	))
+	if expectedTitle != title {
+		t.Fatalf("Expect the page title to change to %q but it was %q", expectedTitle, title)
+	}
+}
+
+func Test003PropDumpDocument(t *testing.T) {
+	pkgName := pkg.PkgName(t)
+	tmpl.CreateIndexHtml(t, pkgName)
+
+	url := "http://vugu-nginx/" + pkgName
+	log.Printf("URL: %s", url)
+
+	ctx, cancel := chromedpHelper.MustChromeCtx()
+	defer cancel()
+
+	var nodes []*cdp.Node
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(url),
+		chromedp.Nodes(`document`, &nodes,
+			chromedp.ByJSPath, chromedp.Populate(-1, true)),
+	); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("Document tree:")
+	fmt.Println(nodes[0].Dump("  ", "  ", false))
+	t.Fatalf("This is the html and the <head> block from %q and not from %q. Conclusion. The <head> block is not replaced, so full html mode does not work.", "index.html", "root.vugu")
 }


### PR DESCRIPTION
Full html support appears to be broken.

The wasm test test-003-prop is the only test in the wasm test suite to use a "full html" mode i.e. the root components vugu file, root.vugu, starts with <html> and contains one top level element in the <body>.

The new test Test003PropTitleChange tries to confirm that the <title> value in the root.vugu file, replaces the value in the <title> tag in the index.html file.

This test fails. The title is not changed and matches the <title> value in the index.html.

Further, test Test003PropDumpDocuemnt confirms this. The test dumps the html nodes of the page. It clearly shows that the <head> tag is unchanged (this is not what is expected), and that the body has been correctly updated at the #vugu_mount_point (as defined in the index.html) with the contents that vugu would generate.